### PR TITLE
feat: add MCP tab routing to Google Sheets reporter

### DIFF
--- a/tests/plugins/google_sheets_reporter/pytest_google_sheets.py
+++ b/tests/plugins/google_sheets_reporter/pytest_google_sheets.py
@@ -238,7 +238,8 @@ def detect_test_category(item) -> str:
         'integration': 'End-To-End',
         'database': MULTI_DB_SUPPORT,
         'google_sheets': 'Google Sheets Integration',
-        'summary': 'Summary'
+        'summary': 'Summary',
+        'mcp': 'MCP',
     }
 
     for keyword, worksheet in path_worksheet_map.items():
@@ -265,6 +266,7 @@ class GoogleSheetsPlugin:
         LLM_OLLAMA_CLIENT,
         LLM_OPENAI_CLIENT,
         LLM_CONTEXTUAL_CLIENT,
+        'MCP',
     }
 
     def __init__(self, config):
@@ -297,6 +299,7 @@ class GoogleSheetsPlugin:
                 LLM_CONTEXTUAL_CLIENT,
                 COMPLETE_USER_ISOLATION,
                 'Summary',
+                'MCP',
             ]
 
             for worksheet_name in worksheets:


### PR DESCRIPTION
Add MCP tab routing to the Google Sheets pytest reporter so that test results
from all MCP unit tests are automatically reported to the 'MCP' worksheet.

Without this change, MCP test results are not picked up by the reporter and
the sheet is never updated with pass/fail status.

Changes:
- Added 'mcp' → 'MCP' to the path_worksheet_map routing dict
- Added 'MCP' to the UPDATABLE_WORKSHEETS set
- Added 'MCP' to the worksheets initialisation list in GoogleSheetsPlugin

📁 Files Changed
tests/plugins/google_sheets_reporter/pytest_google_sheets.py