### PR TITLE
Fix(findrive): reject whitespace-only filenames before DB write

### DIFF
--- a/finbot/mcp/servers/findrive/server.py
+++ b/finbot/mcp/servers/findrive/server.py
@@ -59,6 +59,9 @@ def create_findrive_server(
         if len(content.encode("utf-8")) > max_size:
             return {"error": f"File exceeds maximum size of {config.get('max_file_size_kb', 500)}KB"}
 
+        if not filename or not filename.strip():
+            return {"error": "filename is required and cannot be empty or whitespace"}
+
         with db_session() as db:
             repo = FinDriveFileRepository(db, session_context)
 


### PR DESCRIPTION
## Summary
Fixes #354
Guards `upload_file` against whitespace-only filenames that would create
unresolvable file records in the index.

## Problem
`upload_file` validated only content size before calling `repo.create_file()`.
A caller passing `filename=' '` would successfully persist a record with a
whitespace filename, making it permanently unsearchable.

## Root Cause
No presence/strip check existed on `filename` prior to the DB write path.

## Solution
Two-line guard inserted immediately after the existing `max_size` check:
```python
if not filename or not filename.strip():
    return {"error": "filename is required and cannot be empty or whitespace"}
```
Matches the existing early-return error pattern; no other code touched.

## Impact
- No breaking changes
- Minimal diff (2 lines added)
- Deterministic behavior
- Zero regression risk

## Testing
```bash
pytest tests/unit/mcp/test_findrive.py::TestStrFieldEdgeCases::test_fd_str_001_whitespace_filename_accepted_without_validation -v
pytest tests/unit/mcp/test_findrive.py::TestUpload::test_fd_upload_001_upload_returns_file_id_and_metadata -v
```