### PR TITLE
fix(security): remove CSRF leak and add CSP headers

### DIFF
--- a/finbot/core/auth/middleware.py
+++ b/finbot/core/auth/middleware.py
@@ -152,7 +152,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.tailwindcss.com https://cdn.jsdelivr.net; "
+            "script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; "
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
             "font-src 'self' https://fonts.gstatic.com; "
             "img-src 'self' data: https://gravatar.com https://secure.gravatar.com; "

--- a/finbot/core/auth/middleware.py
+++ b/finbot/core/auth/middleware.py
@@ -149,7 +149,15 @@ class SessionMiddleware(BaseHTTPMiddleware):
         """Add security headers"""
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
-        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; "
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+            "font-src 'self' https://fonts.gstatic.com; "
+            "img-src 'self' data:; "
+            "connect-src 'self';"
+        )
 
 
 # Dependencies for FastAPI routes

--- a/finbot/core/auth/middleware.py
+++ b/finbot/core/auth/middleware.py
@@ -152,11 +152,11 @@ class SessionMiddleware(BaseHTTPMiddleware):
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; "
+            "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.tailwindcss.com https://cdn.jsdelivr.net; "
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
             "font-src 'self' https://fonts.gstatic.com; "
-            "img-src 'self' data:; "
-            "connect-src 'self';"
+            "img-src 'self' data: https://gravatar.com https://secure.gravatar.com; "
+            "connect-src 'self' ws: wss:;"
         )
 
 

--- a/finbot/main.py
+++ b/finbot/main.py
@@ -230,7 +230,6 @@ async def session_status(
         "is_temporary": session_context.is_temporary,
         "namespace": session_context.namespace,
         "security_status": session_context.get_security_status(),
-        "csrf_token": session_context.csrf_token,
     }
 
 


### PR DESCRIPTION
## Summary

Fixes two security issues in the HTTP response layer: removes the CSRF token from a
publicly accessible JSON endpoint and adds a `Content-Security-Policy` header while
removing the deprecated `X-XSS-Protection` header.

Fixes #503 

---

## Changes

### `finbot/main.py`

**1. CSRF token removed from `/api/session/status` response.**

CSRF tokens must only be injected into HTML (meta tags / hidden form fields).
Returning them from a GET JSON endpoint allows any XSS payload to trivially read
and replay the token.

```diff
  return {
      "session_id": session_context.session_id[:8] + "...",
      "user_id": session_context.user_id,
      "is_temporary": session_context.is_temporary,
      "namespace": session_context.namespace,
      "security_status": session_context.get_security_status(),
-     "csrf_token": session_context.csrf_token,
+     # csrf_token intentionally omitted - injected via HTML meta tag only
  }
```

### `finbot/core/auth/middleware.py`

**2. Added `Content-Security-Policy` and `Referrer-Policy`; removed deprecated `X-XSS-Protection`.**

```diff
  def _add_security_headers(self, response: Response):
      response.headers["X-Content-Type-Options"] = "nosniff"
      response.headers["X-Frame-Options"] = "DENY"
-     response.headers["X-XSS-Protection"] = "1; mode=block"
+     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+     response.headers["Content-Security-Policy"] = (
+         "default-src 'self'; "
+         "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; "
+         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+         "font-src 'self' https://fonts.gstatic.com; "
+         "img-src 'self' data:; "
+         "connect-src 'self';"
+     )
```

---

## Why This Matters

| Before | After | Risk Removed |
|--------|-------|-------------|
| `csrf_token` in GET JSON response | Omitted from JSON; HTML-only | XSS payload can steal CSRF token via `fetch()` |
| No `Content-Security-Policy` header | Baseline CSP added | Injected `<script>` tags execute without restriction |
| `X-XSS-Protection: 1; mode=block` | Removed | Deprecated header (Chrome 78+ ignores it); can introduce bugs in old browsers |

---

## Testing

- [x] `GET /api/session/status` response no longer contains `csrf_token` field
- [x] CSRF-protected POST endpoints (`/auth/magic-link` etc.) still work correctly —
  token is read from the HTML meta tag as before
- [x] Response headers now include `Content-Security-Policy` on every page
- [x] `X-XSS-Protection` is no longer present in response headers
- [x] `Referrer-Policy: strict-origin-when-cross-origin` is present in response headers

---

## Notes for Reviewers

- The CSP policy uses `'unsafe-inline'` for scripts and styles because the current
  templates use inline `<script>` and `<style>` blocks. A follow-up issue should
  introduce nonce-based CSP to remove `'unsafe-inline'` entirely.
- No template changes are required - CSRF tokens are already injected as HTML meta
  tags in the base templates; this PR only removes the redundant JSON exposure.
