### PR TITLE
Fix .gitignore to include node_modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,7 @@ google-credentials.json
 SECURITY_BUGS_REPORT.md
 
 
-.node_modules/
+node_modules/
 
 # SQLite databases
 *.db


### PR DESCRIPTION
This PR was created because there was issue with .gitignore .
It was not ignoring the nodemodules.