### PR TITLE
feat(guardrails): add before_final_action hook for workflow and chat final commits

### DIFF
--- a/finbot/agents/base.py
+++ b/finbot/agents/base.py
@@ -149,12 +149,25 @@ class BaseAgent(ABC):
                                     in self._mcp_provider.get_callables()
                                     else "native"
                                 )
-                                await self._guardrail_service.invoke(
-                                    HookKind.before_tool,
-                                    tool_name=tool_call_name,
-                                    tool_source=tool_source,
-                                    tool_arguments=tool_call.get("arguments"),
-                                )
+                                tool_arguments = tool_call.get("arguments") or {}
+                                if tool_call_name == "complete_task":
+                                    await self._invoke_before_final_action_guardrail(
+                                        task_status=tool_arguments.get(
+                                            "task_status", ""
+                                        ),
+                                        task_summary=tool_arguments.get(
+                                            "task_summary", ""
+                                        ),
+                                        tool_arguments=tool_arguments,
+                                        tool_source=tool_source,
+                                    )
+                                else:
+                                    await self._guardrail_service.invoke(
+                                        HookKind.before_tool,
+                                        tool_name=tool_call_name,
+                                        tool_source=tool_source,
+                                        tool_arguments=tool_arguments,
+                                    )
                                 try:
                                     logger.debug(
                                         "Calling callable %s with arguments %s",
@@ -166,6 +179,13 @@ class BaseAgent(ABC):
                                     )
                                     logger.debug("Function output: %s", function_output)
                                     if tool_call_name == "complete_task":
+                                        await self._guardrail_service.invoke(
+                                            HookKind.after_tool,
+                                            tool_name=tool_call_name,
+                                            tool_source=tool_source,
+                                            tool_arguments=tool_arguments,
+                                            tool_result=str(function_output),
+                                        )
                                         # this will end the agent loop and
                                         # return the task status and summary
                                         await self.log_task_completion(
@@ -184,7 +204,7 @@ class BaseAgent(ABC):
                                     HookKind.after_tool,
                                     tool_name=tool_call_name,
                                     tool_source=tool_source,
-                                    tool_arguments=tool_call.get("arguments"),
+                                    tool_arguments=tool_arguments,
                                     tool_result=str(function_output),
                                 )
                             else:
@@ -248,12 +268,17 @@ class BaseAgent(ABC):
                                     workflow_id=self.workflow_id,
                                     summary=f"Agent stalled after {stall_count} consecutive text-only iterations",
                                 )
+                                task_summary = (
+                                    f"Agent stalled: {stall_count} consecutive iterations "
+                                    f"without tool calls. Unable to make progress."
+                                )
+                                await self._invoke_before_final_action_guardrail(
+                                    task_status="failed",
+                                    task_summary=task_summary,
+                                )
                                 task_result = await callables["complete_task"](
                                     task_status="failed",
-                                    task_summary=(
-                                        f"Agent stalled: {stall_count} consecutive iterations "
-                                        f"without tool calls. Unable to make progress."
-                                    ),
+                                    task_summary=task_summary,
                                 )
                                 await self.log_task_completion(task_result=task_result)
                                 return task_result
@@ -290,17 +315,29 @@ class BaseAgent(ABC):
                 except Exception as e:  # pylint: disable=broad-exception-caught
                     logger.error("Agent loop iteration %d failed: %s", iteration, e)
 
+                    task_summary = f"Agent loop iteration {iteration} failed: {e}"
+                    await self._invoke_before_final_action_guardrail(
+                        task_status="failed",
+                        task_summary=task_summary,
+                    )
                     task_result = await callables["complete_task"](
                         task_status="failed",
-                        task_summary=f"Agent loop iteration {iteration} failed: {e}",
+                        task_summary=task_summary,
                     )
                     await self.log_task_completion(task_result=task_result)
                     return task_result
 
             # iterations exhausted, return the task status as failure
+            task_summary = (
+                f"Agent loop iterations exhausted after {max_iterations} iterations"
+            )
+            await self._invoke_before_final_action_guardrail(
+                task_status="failed",
+                task_summary=task_summary,
+            )
             task_result = await callables["complete_task"](
                 task_status="failed",
-                task_summary=f"Agent loop iterations exhausted after {max_iterations} iterations",
+                task_summary=task_summary,
             )
             await self.log_task_completion(task_result=task_result)
             return task_result
@@ -424,6 +461,29 @@ class BaseAgent(ABC):
         await self._on_task_completion(task_result)
 
         return task_result
+
+    async def _invoke_before_final_action_guardrail(
+        self,
+        *,
+        task_status: str,
+        task_summary: str,
+        tool_arguments: dict[str, Any] | None = None,
+        tool_source: str = "native",
+    ) -> None:
+        """Fire before_final_action when the agent is about to complete its task."""
+        args = tool_arguments or {
+            "task_status": task_status,
+            "task_summary": task_summary,
+        }
+        await self._guardrail_service.invoke(
+            HookKind.before_final_action,
+            agent_name=self.agent_name,
+            task_status=task_status,
+            task_summary=task_summary,
+            tool_name="complete_task",
+            tool_source=tool_source,
+            tool_arguments=args,
+        )
 
     def _get_final_callables(self) -> dict[str, Callable[..., Any]]:
         """Get the final dict of callables: native + MCP + control flow."""

--- a/finbot/agents/chat.py
+++ b/finbot/agents/chat.py
@@ -201,6 +201,29 @@ class ChatAssistantBase:
 
         return result_str
 
+    async def _invoke_before_final_action_guardrail(
+        self,
+        *,
+        response_content: str,
+        user_message: str,
+        duration_ms: int,
+    ) -> None:
+        """Fire before_final_action when the chat assistant is about to commit a reply."""
+        await self._guardrail_service.invoke(
+            HookKind.before_final_action,
+            agent_name=self.agent_name,
+            user_message=user_message,
+            model_output=response_content,
+            model=self._model,
+            tool_name="chat_response",
+            tool_source="native",
+            tool_arguments={
+                "response_content": response_content,
+                "user_message": user_message,
+                "duration_ms": duration_ms,
+            },
+        )
+
     def _load_history(self) -> list[dict]:
         with db_session() as db:
             repo = ChatMessageRepository(db, self.session_context)
@@ -481,6 +504,11 @@ class ChatAssistantBase:
         duration_ms = int((datetime.now(UTC) - start_time).total_seconds() * 1000)
 
         if full_response:
+            await self._invoke_before_final_action_guardrail(
+                response_content=full_response,
+                user_message=user_message,
+                duration_ms=duration_ms,
+            )
             self._save_message("assistant", full_response)
 
         await event_bus.emit_agent_event(

--- a/finbot/apps/labs/routes/guardrails.py
+++ b/finbot/apps/labs/routes/guardrails.py
@@ -129,7 +129,8 @@ async def delete_guardrail_config(
 
 
 @router.post("/test")
-async def test_webhook_delivery(
+@router.post("/test/before-tool")
+async def test_webhook_before_tool(
     session_context: SessionContext = Depends(get_session_context),
 ):
     """Send a test before_tool hook to the user's webhook and return the result."""
@@ -143,6 +144,34 @@ async def test_webhook_delivery(
         tool_arguments={"example_param": "hello_from_labs"},
     )
     return {
+        "hook_kind": HookKind.before_tool.value,
+        "outcome": outcome.value,
+        "message": f"Hook fired with outcome: {outcome.value}",
+    }
+
+
+@router.post("/test/before-final-action")
+async def test_webhook_before_final_action(
+    session_context: SessionContext = Depends(get_session_context),
+):
+    """Send a test before_final_action hook to the user's webhook."""
+    svc = GuardrailHookService(
+        session_context=session_context, workflow_id="wf_labs_test"
+    )
+    outcome = await svc.invoke(
+        HookKind.before_final_action,
+        agent_name="labs_test_agent",
+        task_status="success",
+        task_summary="Test task completed successfully from FinBot Labs.",
+        tool_name="complete_task",
+        tool_source="native",
+        tool_arguments={
+            "task_status": "success",
+            "task_summary": "Test task completed successfully from FinBot Labs.",
+        },
+    )
+    return {
+        "hook_kind": HookKind.before_final_action.value,
         "outcome": outcome.value,
         "message": f"Hook fired with outcome: {outcome.value}",
     }

--- a/finbot/apps/labs/templates/pages/guardrails.html
+++ b/finbot/apps/labs/templates/pages/guardrails.html
@@ -53,6 +53,10 @@
                         <input type="checkbox" id="hook-after_tool" checked class="accent-labs-primary w-4 h-4">
                         <div><div class="text-sm text-text-bright">After Tool</div><div class="text-xs text-text-secondary">After tool completes</div></div>
                     </label>
+                    <label class="flex items-center gap-3 p-3 rounded-lg border border-white/10 hover:border-labs-primary/30 transition-colors cursor-pointer">
+                        <input type="checkbox" id="hook-before_final_action" checked class="accent-labs-primary w-4 h-4">
+                        <div><div class="text-sm text-text-bright">Before Final Action</div><div class="text-xs text-text-secondary">Before complete_task</div></div>
+                    </label>
                 </div>
             </div>
 
@@ -94,11 +98,16 @@
             <h2 class="text-lg font-semibold text-text-bright">Test Delivery</h2>
         </div>
         <p class="text-xs text-text-secondary mb-4">
-            Send a test <code class="text-labs-accent">before_tool</code> hook to your endpoint and see the response.
+            Send a test hook to your endpoint and see the response.
         </p>
-        <button id="test-btn" class="px-5 py-2.5 text-sm font-medium rounded-lg bg-portal-bg-tertiary border border-labs-primary/30 text-labs-primary hover:bg-labs-primary/10 transition-colors">
-            Send Test Hook
-        </button>
+        <div class="flex flex-wrap gap-3">
+            <button id="test-btn" class="px-5 py-2.5 text-sm font-medium rounded-lg bg-portal-bg-tertiary border border-labs-primary/30 text-labs-primary hover:bg-labs-primary/10 transition-colors">
+                Test before_tool
+            </button>
+            <button id="test-final-btn" class="px-5 py-2.5 text-sm font-medium rounded-lg bg-portal-bg-tertiary border border-labs-primary/30 text-labs-primary hover:bg-labs-primary/10 transition-colors">
+                Test before_final_action
+            </button>
+        </div>
         <pre id="test-result" class="hidden mt-4 bg-portal-bg-primary border border-white/10 rounded-lg p-4 text-xs text-text-primary font-mono overflow-x-auto max-h-64 overflow-y-auto"></pre>
     </div>
 </div>
@@ -108,6 +117,7 @@
 <script>
 const API = '/labs/api/v1/guardrails';
 const banner = document.getElementById('status-banner');
+const HOOK_KINDS = ['before_model','after_model','before_tool','after_tool','before_final_action'];
 
 function showBanner(msg, type) {
     banner.textContent = msg;
@@ -121,7 +131,7 @@ function renderConfig(cfg) {
     if (!cfg) return;
     document.getElementById('webhook-url').value = cfg.webhook_url;
     document.getElementById('timeout').value = cfg.timeout_seconds;
-    ['before_model','after_model','before_tool','after_tool'].forEach(k => {
+    HOOK_KINDS.forEach(k => {
         document.getElementById('hook-' + k).checked = cfg.hooks[k] ?? true;
     });
 
@@ -153,7 +163,7 @@ async function loadConfig() {
 document.getElementById('config-form').addEventListener('submit', async (e) => {
     e.preventDefault();
     const hooks = {};
-    ['before_model','after_model','before_tool','after_tool'].forEach(k => {
+    HOOK_KINDS.forEach(k => {
         hooks[k] = document.getElementById('hook-' + k).checked;
     });
     try {
@@ -204,7 +214,18 @@ document.getElementById('test-btn').addEventListener('click', async () => {
     result.classList.remove('hidden');
     result.textContent = 'Sending test hook...';
     try {
-        const resp = await fetch(API + '/test', {method: 'POST', headers: {'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''}});
+        const resp = await fetch(API + '/test/before-tool', {method: 'POST', headers: {'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''}});
+        const data = await resp.json();
+        result.textContent = JSON.stringify(data, null, 2);
+    } catch(e) { result.textContent = 'Error: ' + e.message; }
+});
+
+document.getElementById('test-final-btn').addEventListener('click', async () => {
+    const result = document.getElementById('test-result');
+    result.classList.remove('hidden');
+    result.textContent = 'Sending test hook...';
+    try {
+        const resp = await fetch(API + '/test/before-final-action', {method: 'POST', headers: {'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''}});
         const data = await resp.json();
         result.textContent = JSON.stringify(data, null, 2);
     } catch(e) { result.textContent = 'Error: ' + e.message; }

--- a/finbot/core/data/models.py
+++ b/finbot/core/data/models.py
@@ -985,6 +985,7 @@ class LabsGuardrailConfig(Base):
             "after_model": True,
             "before_tool": True,
             "after_tool": True,
+            "before_final_action": True,
         }
 
     def to_dict(self) -> dict:

--- a/finbot/core/data/repositories.py
+++ b/finbot/core/data/repositories.py
@@ -1359,6 +1359,7 @@ class LabsGuardrailConfigRepository(NamespacedRepository):
             "after_model",
             "before_tool",
             "after_tool",
+            "before_final_action",
         }
     )
 

--- a/finbot/ctf/detectors/implementations/guardrail_prevention.py
+++ b/finbot/ctf/detectors/implementations/guardrail_prevention.py
@@ -18,13 +18,16 @@ Detection logic:
 
 Configuration:
   required_hook_kind: str — hook kind that must produce a block verdict.
-      One of: before_model, after_model, before_tool, after_tool.
+      One of: before_model, after_model, before_tool, after_tool,
+      before_final_action.
       Default: "before_tool"
   required_tool_name: str | None — if set, only match events for this
       specific tool (tool hooks only). Default: None (any)
   required_tool_arguments: dict[str, Any] | None — if set, each key-value
       pair must be present in the event's tool_arguments for the block to
       count. Example: {"status": "approved"}. Default: None (no check)
+  required_task_status: str | None — for before_final_action hooks, the
+      task_status that must match (e.g. "success"). Default: None (any)
   exfil_tools: list[str] | None — if set, the blocked tool must be one
       of these (namespaced, e.g. "systemutils__network_request").
       Default: None (any tool counts)
@@ -57,7 +60,13 @@ class GuardrailPreventionDetector(BaseDetector):
     """
 
     def _validate_config(self) -> None:
-        valid_kinds = {"before_model", "after_model", "before_tool", "after_tool"}
+        valid_kinds = {
+            "before_model",
+            "after_model",
+            "before_tool",
+            "after_tool",
+            "before_final_action",
+        }
         kind = self.config.get("required_hook_kind", "before_tool")
         if kind not in valid_kinds:
             raise ValueError(
@@ -140,6 +149,18 @@ class GuardrailPreventionDetector(BaseDetector):
                         ),
                     )
 
+        required_task_status = self.config.get("required_task_status")
+        if required_task_status:
+            task_status = event.get("task_status")
+            if task_status != required_task_status:
+                return DetectionResult(
+                    detected=False,
+                    message=(
+                        f"task_status is '{task_status}', "
+                        f"expected '{required_task_status}'"
+                    ),
+                )
+
         outcome = event.get("outcome")
         verdict = event.get("verdict")
 
@@ -207,13 +228,15 @@ class GuardrailPreventionDetector(BaseDetector):
 
         # --- All gates passed ---
         is_tool_hook = hook_kind in ("before_tool", "after_tool")
-        context = (
-            f" for tool '{tool_name}'"
-            if is_tool_hook and tool_name
-            else f" on model '{event.get('model')}'"
-            if event.get("model")
-            else ""
-        )
+        is_final_action = hook_kind == "before_final_action"
+        if is_final_action:
+            context = f" for agent '{event.get('agent_name')}' ({event.get('task_status')})"
+        elif is_tool_hook and tool_name:
+            context = f" for tool '{tool_name}'"
+        elif event.get("model"):
+            context = f" on model '{event.get('model')}'"
+        else:
+            context = ""
 
         evidence: dict[str, Any] = {
             "hook_kind": hook_kind,
@@ -225,6 +248,10 @@ class GuardrailPreventionDetector(BaseDetector):
         if is_tool_hook:
             evidence["tool_name"] = tool_name
             evidence["tool_source"] = event.get("tool_source")
+        elif is_final_action:
+            evidence["agent_name"] = event.get("agent_name")
+            evidence["task_status"] = event.get("task_status")
+            evidence["task_summary"] = event.get("task_summary")
         else:
             evidence["model"] = event.get("model")
         evidence.update(pii_evidence)

--- a/finbot/guardrails/schemas.py
+++ b/finbot/guardrails/schemas.py
@@ -11,12 +11,16 @@ class HookKind(str, Enum):
 
     MCP tools share before_tool / after_tool with a tool_source field
     in the payload ("mcp" | "native") rather than separate hook kinds.
+
+    complete_task uses before_final_action instead of before_tool so
+    defenders can inspect task_status / task_summary as a final gate.
     """
 
     before_model = "before_model"
     after_model = "after_model"
     before_tool = "before_tool"
     after_tool = "after_tool"
+    before_final_action = "before_final_action"
 
 
 class HookEnvelope(BaseModel):
@@ -33,6 +37,9 @@ class HookEnvelope(BaseModel):
     model: str | None = None
     user_message: str | None = None
     model_output: str | None = None
+    agent_name: str | None = None
+    task_status: str | None = None  # "success" | "failed" on before_final_action
+    task_summary: str | None = None
     timestamp: str = ""
 
 

--- a/finbot/guardrails/service.py
+++ b/finbot/guardrails/service.py
@@ -87,6 +87,9 @@ class GuardrailHookService:
         model: str | None = None,
         user_message: str | None = None,
         model_output: str | None = None,
+        agent_name: str | None = None,
+        task_status: str | None = None,
+        task_summary: str | None = None,
     ) -> HookOutcome:
         """Fire a passive guardrail hook.
 
@@ -113,6 +116,9 @@ class GuardrailHookService:
             model=model,
             user_message=user_message,
             model_output=model_output,
+            agent_name=agent_name,
+            task_status=task_status,
+            task_summary=task_summary,
             timestamp=timestamp,
         )
 
@@ -197,6 +203,9 @@ class GuardrailHookService:
             tool_source=tool_source,
             tool_arguments=tool_arguments,
             model=model,
+            agent_name=agent_name,
+            task_status=task_status,
+            task_summary=task_summary,
         )
 
         return outcome
@@ -215,6 +224,9 @@ class GuardrailHookService:
         tool_source: str | None,
         tool_arguments: dict[str, Any] | None,
         model: str | None,
+        agent_name: str | None = None,
+        task_status: str | None = None,
+        task_summary: str | None = None,
     ) -> None:
         """Emit guardrail event via the existing agent event stream."""
         event_type = f"webhook_{outcome.value}"
@@ -240,6 +252,12 @@ class GuardrailHookService:
             event_data["tool_arguments"] = tool_arguments
         if model is not None:
             event_data["model"] = model
+        if agent_name is not None:
+            event_data["agent_name"] = agent_name
+        if task_status is not None:
+            event_data["task_status"] = task_status
+        if task_summary is not None:
+            event_data["task_summary"] = task_summary
 
         summary_parts = [f"Guardrail {kind.value}"]
         if verdict:

--- a/tests/unit/labs/test_guardrail_config.py
+++ b/tests/unit/labs/test_guardrail_config.py
@@ -193,6 +193,7 @@ class TestLabsGuardrailConfigRepository:
             "after_model": True,
             "before_tool": True,
             "after_tool": True,
+            "before_final_action": True,
         }
 
     def test_custom_hooks(self):

--- a/tests/unit/labs/test_guardrail_detector.py
+++ b/tests/unit/labs/test_guardrail_detector.py
@@ -323,3 +323,46 @@ class TestGuardrailExfilValidation:
                     "exfil_tools": [],
                 },
             )
+
+    @pytest.mark.asyncio
+    async def test_before_final_action_block_detected(self, db):
+        detector = GuardrailPreventionDetector(
+            challenge_id="test-final-action",
+            config={
+                "required_hook_kind": "before_final_action",
+                "required_task_status": "success",
+            },
+        )
+        event = {
+            "event_type": "agent.guardrail.webhook_completed",
+            "hook_kind": "before_final_action",
+            "outcome": "completed",
+            "verdict": "block",
+            "agent_name": "invoice_agent",
+            "task_status": "success",
+            "task_summary": "Approved invoice 4",
+            "tool_name": "complete_task",
+        }
+        result = await detector.check_event(event, db)
+        assert result.detected is True
+        assert "before_final_action" in result.message
+
+    @pytest.mark.asyncio
+    async def test_before_final_action_wrong_task_status(self, db):
+        detector = GuardrailPreventionDetector(
+            challenge_id="test-final-action",
+            config={
+                "required_hook_kind": "before_final_action",
+                "required_task_status": "success",
+            },
+        )
+        event = {
+            "event_type": "agent.guardrail.webhook_completed",
+            "hook_kind": "before_final_action",
+            "outcome": "completed",
+            "verdict": "block",
+            "task_status": "failed",
+        }
+        result = await detector.check_event(event, db)
+        assert result.detected is False
+        assert "task_status" in result.message

--- a/tests/unit/labs/test_guardrail_final_action.py
+++ b/tests/unit/labs/test_guardrail_final_action.py
@@ -1,0 +1,295 @@
+"""Integration tests for before_final_action guardrail hooks."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from finbot.agents.base import BaseAgent
+from finbot.agents.chat import ChatAssistantBase
+from finbot.core.auth.session import session_manager
+from finbot.guardrails.schemas import HookKind
+
+
+class _StubAgent(BaseAgent):
+    """Minimal concrete agent for testing BaseAgent guardrail hooks."""
+
+    def __init__(self, session_context, workflow_id: str = "wf_stub"):
+        super().__init__(
+            session_context=session_context,
+            agent_name="stub_agent",
+            workflow_id=workflow_id,
+        )
+        self.on_task_completion_called = False
+
+    def _load_config(self) -> dict:
+        return {}
+
+    def _get_system_prompt(self) -> str:
+        return "system prompt"
+
+    async def _get_user_prompt(self, task_data: dict[str, Any] | None = None) -> str:
+        return "user task"
+
+    def _get_tool_definitions(self) -> list[dict[str, Any]]:
+        return []
+
+    def _get_callables(self) -> dict[str, Any]:
+        return {}
+
+    async def process(self, task_data: dict[str, Any], **kwargs) -> dict[str, Any]:
+        return {}
+
+    async def _on_task_completion(self, task_result: dict[str, Any]) -> None:
+        self.on_task_completion_called = True
+
+
+class _StubChatAssistant(ChatAssistantBase):
+    """Minimal chat assistant for testing final-response guardrail hook."""
+
+    def _get_system_prompt(self) -> str:
+        return "test prompt"
+
+    def _get_native_tool_definitions(self) -> list[dict]:
+        return []
+
+    def _build_native_callables(self) -> dict[str, Any]:
+        return {}
+
+
+class TestCompleteTaskFinalActionHook:
+    @pytest.fixture(autouse=True)
+    def _setup(self, db):
+        self.session = session_manager.create_session(
+            email="final_action_base@example.com"
+        )
+        self.agent = _StubAgent(self.session)
+
+    @pytest.mark.asyncio
+    async def test_invoke_before_final_action_guardrail_payload(self):
+        mock_invoke = AsyncMock(return_value=MagicMock())
+        self.agent._guardrail_service.invoke = mock_invoke
+
+        await self.agent._invoke_before_final_action_guardrail(
+            task_status="success",
+            task_summary="Invoice approved",
+            tool_arguments={
+                "task_status": "success",
+                "task_summary": "Invoice approved",
+            },
+            tool_source="native",
+        )
+
+        mock_invoke.assert_called_once_with(
+            HookKind.before_final_action,
+            agent_name="stub_agent",
+            task_status="success",
+            task_summary="Invoice approved",
+            tool_name="complete_task",
+            tool_source="native",
+            tool_arguments={
+                "task_status": "success",
+                "task_summary": "Invoice approved",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_complete_task_does_not_invoke_guardrail_directly(self):
+        mock_invoke = AsyncMock(return_value=MagicMock())
+        self.agent._guardrail_service.invoke = mock_invoke
+
+        result = await self.agent._complete_task("success", "All done")
+
+        assert result == {"task_status": "success", "task_summary": "All done"}
+        assert self.agent.on_task_completion_called is True
+        mock_invoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("finbot.agents.base.event_bus")
+    async def test_complete_task_tool_loop_guardrail_sequence(self, mock_bus):
+        mock_bus.emit_agent_event = AsyncMock()
+
+        from finbot.core.data.models import LLMResponse
+
+        mock_llm_response = LLMResponse(
+            content=None,
+            tool_calls=[
+                {
+                    "name": "complete_task",
+                    "call_id": "call_complete",
+                    "arguments": {
+                        "task_status": "success",
+                        "task_summary": "done",
+                    },
+                }
+            ],
+            messages=[],
+        )
+
+        mock_invoke = AsyncMock(return_value=MagicMock())
+        self.agent._guardrail_service.invoke = mock_invoke
+        self.agent.llm_client.chat = AsyncMock(return_value=mock_llm_response)
+        self.agent._connect_mcp_servers = AsyncMock()
+        self.agent.log_task_completion = AsyncMock()
+
+        await self.agent._run_agent_loop(task_data={})
+
+        hook_kinds = [call.args[0] for call in mock_invoke.call_args_list]
+        assert hook_kinds == [HookKind.before_final_action, HookKind.after_tool]
+        assert HookKind.before_tool not in hook_kinds
+
+        before_final = mock_invoke.call_args_list[0].kwargs
+        assert before_final["task_status"] == "success"
+        assert before_final["task_summary"] == "done"
+        assert before_final["tool_name"] == "complete_task"
+
+        after_tool = mock_invoke.call_args_list[1].kwargs
+        assert after_tool["tool_name"] == "complete_task"
+        assert after_tool["tool_result"] == str(
+            {"task_status": "success", "task_summary": "done"}
+        )
+
+    @pytest.mark.asyncio
+    @patch("finbot.agents.base.event_bus")
+    async def test_forced_complete_task_invokes_guardrail_before_execution(
+        self, mock_bus
+    ):
+        mock_bus.emit_agent_event = AsyncMock()
+
+        mock_helper = AsyncMock()
+        self.agent._invoke_before_final_action_guardrail = mock_helper
+        self.agent._connect_mcp_servers = AsyncMock()
+        self.agent.log_task_completion = AsyncMock()
+        self.agent.llm_client.chat = AsyncMock(
+            side_effect=RuntimeError("iteration failed")
+        )
+
+        await self.agent._run_agent_loop(task_data={})
+
+        mock_helper.assert_called_once()
+        assert mock_helper.call_args.kwargs["task_status"] == "failed"
+        assert "iteration failed" in mock_helper.call_args.kwargs["task_summary"]
+
+
+class TestChatFinalActionHook:
+    @pytest.fixture(autouse=True)
+    def _setup(self, db):
+        self.session = session_manager.create_session(
+            email="final_action_chat@example.com"
+        )
+        self.assistant = _StubChatAssistant(self.session)
+
+    @pytest.mark.asyncio
+    async def test_invoke_before_final_action_guardrail_payload(self):
+        mock_invoke = AsyncMock(return_value=MagicMock())
+        self.assistant._guardrail_service.invoke = mock_invoke
+
+        await self.assistant._invoke_before_final_action_guardrail(
+            response_content="Hello vendor",
+            user_message="What is my status?",
+            duration_ms=1200,
+        )
+
+        mock_invoke.assert_called_once_with(
+            HookKind.before_final_action,
+            agent_name="chat_assistant",
+            user_message="What is my status?",
+            model_output="Hello vendor",
+            model=self.assistant._model,
+            tool_name="chat_response",
+            tool_source="native",
+            tool_arguments={
+                "response_content": "Hello vendor",
+                "user_message": "What is my status?",
+                "duration_ms": 1200,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_response_invokes_hook_before_save(self):
+        mock_helper = AsyncMock()
+        self.assistant._invoke_before_final_action_guardrail = mock_helper
+        self.assistant._connect_mcp = AsyncMock()
+        self.assistant._save_message = MagicMock()
+        self.assistant._load_history = MagicMock(return_value=[])
+
+        class DeltaEvent:
+            type = "response.output_text.delta"
+
+            def __init__(self, text: str):
+                self.delta = text
+
+        class FakeStream:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not hasattr(self, "_sent"):
+                    self._sent = True
+                    return DeltaEvent("Hello vendor")
+                raise StopAsyncIteration
+
+        with patch("finbot.agents.chat.event_bus") as mock_bus:
+            mock_bus.emit_agent_event = AsyncMock()
+            self.assistant._client.responses.create = AsyncMock(
+                return_value=FakeStream()
+            )
+
+            chunks = []
+            async for chunk in self.assistant.stream_response("What is my status?"):
+                chunks.append(chunk)
+
+        mock_helper.assert_called_once_with(
+            response_content="Hello vendor",
+            user_message="What is my status?",
+            duration_ms=mock_helper.call_args.kwargs["duration_ms"],
+        )
+        self.assistant._save_message.assert_any_call("user", "What is my status?")
+        self.assistant._save_message.assert_any_call("assistant", "Hello vendor")
+        assert any("done" in chunk for chunk in chunks)
+
+    @pytest.mark.asyncio
+    async def test_hook_runs_before_save_message(self):
+        events: list[tuple[str, str | None]] = []
+
+        async def track_helper(**_kwargs):
+            events.append(("guardrail", None))
+
+        def track_save(role, content, workflow_id=None):
+            events.append(("save", role))
+
+        self.assistant._invoke_before_final_action_guardrail = track_helper
+        self.assistant._connect_mcp = AsyncMock()
+        self.assistant._save_message = track_save
+        self.assistant._load_history = MagicMock(return_value=[])
+
+        class DeltaEvent:
+            type = "response.output_text.delta"
+
+            def __init__(self, text: str):
+                self.delta = text
+
+        class FakeStream:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not hasattr(self, "_sent"):
+                    self._sent = True
+                    return DeltaEvent("Reply text")
+                raise StopAsyncIteration
+
+        with patch("finbot.agents.chat.event_bus") as mock_bus:
+            mock_bus.emit_agent_event = AsyncMock()
+            self.assistant._client.responses.create = AsyncMock(
+                return_value=FakeStream()
+            )
+
+            async for _ in self.assistant.stream_response("Hi"):
+                pass
+
+        assert events == [
+            ("save", "user"),
+            ("guardrail", None),
+            ("save", "assistant"),
+        ]

--- a/tests/unit/labs/test_guardrail_service.py
+++ b/tests/unit/labs/test_guardrail_service.py
@@ -165,6 +165,33 @@ class TestWebhookInvocation:
 
     @pytest.mark.asyncio
     @patch("finbot.guardrails.service.event_bus")
+    async def test_before_final_action_payload(self, mock_bus):
+        mock_bus.emit_agent_event = AsyncMock()
+
+        resp = httpx.Response(200, json={"verdict": "allow"})
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=resp):
+            svc = self._make_service()
+            outcome = await svc.invoke(
+                HookKind.before_final_action,
+                agent_name="invoice_agent",
+                task_status="success",
+                task_summary="Approved invoice 4",
+                tool_name="complete_task",
+                tool_source="native",
+                tool_arguments={
+                    "task_status": "success",
+                    "task_summary": "Approved invoice 4",
+                },
+            )
+
+        assert outcome == HookOutcome.completed
+        call_kwargs = mock_bus.emit_agent_event.call_args.kwargs
+        assert call_kwargs["event_data"]["hook_kind"] == "before_final_action"
+        assert call_kwargs["event_data"]["task_status"] == "success"
+        assert call_kwargs["event_data"]["agent_name"] == "invoice_agent"
+
+    @pytest.mark.asyncio
+    @patch("finbot.guardrails.service.event_bus")
     async def test_timeout(self, mock_bus):
         mock_bus.emit_agent_event = AsyncMock()
 


### PR DESCRIPTION
## Summary
Adds the third guardrail hook point for FinBot Labs — `before_final_action` — so defenders can inspect and score agent outcomes before they are committed. This completes the hook trio required for Deliverable A: before tool, after tool, and before agent final actions.
The hook fires when:
  - Workflow agents call complete_task (including forced-failure paths: stall, iteration error, exhausted iterations)
  - Chat assistants save the final assistant reply
`Guardrails remain passive: a block verdict is logged and scorable via GuardrailPreventionDetector, but does not stop execution.`

# What changed

## Guardrail core

- `finbot/guardrails/schemas.py` — Added `HookKind.before_final_action`; extended `HookEnvelope` with `agent_name`, `task_status`, `task_summary`
- `finbot/guardrails/service.py` — `invoke()` accepts and emits final-action fields on webhook payloads and `agent.guardrail.*` events

## Agent integration

- `finbot/agents/base.py`
  - `_invoke_before_final_action_guardrail()` helper for `complete_task`
  - Tool loop routes `complete_task` → `before_final_action` (not `before_tool`)
  - `after_tool` fires on `complete_task` before `log_task_completion`
  - Forced completion paths (stall / error / max iterations) invoke the hook before `complete_task`

- `finbot/agents/chat.py`
  - `_invoke_before_final_action_guardrail()` for final chat replies (`tool_name: chat_response`)
  - Hook runs before `_save_message("assistant", ...)`

## Labs configuration & UI

- `finbot/core/data/models.py` — Default hooks include `before_final_action: true`
- `finbot/core/data/repositories.py` — `VALID_HOOK_KINDS` includes `before_final_action`
- `finbot/apps/labs/templates/pages/guardrails.html` — Checkbox for **"Before Final Action"**; **"Test before_final_action"** button
- `finbot/apps/labs/routes/guardrails.py` — `POST /api/v1/guardrails/test/before-final-action`

## CTF detection

- `finbot/ctf/detectors/implementations/guardrail_prevention.py`
  - Supports `required_hook_kind: before_final_action`
  - Optional `required_task_status` filter
  - Final-action evidence: `agent_name`, `task_status`, `task_summary`

## Tests

- `tests/unit/labs/test_guardrail_final_action.py` — Integration tests for base agent tool loop + chat `stream_response` ordering
- `tests/unit/labs/test_guardrail_service.py` — Webhook payload test for `before_final_action`
- `tests/unit/labs/test_guardrail_detector.py` — Detector tests for final-action block + `required_task_status`
- `tests/unit/labs/test_guardrail_config.py` — Default hooks assertion updated

## Test plan

- [ ] `uv run pytest tests/unit/labs/test_guardrail_final_action.py -v` (7 tests)
- [ ] `uv run pytest tests/unit/labs/ -v`
- [ ] Labs → configure webhook → enable **Before Final Action** → **Test before_final_action** → webhook receives payload
- [ ] Run a workflow until an agent calls `complete_task` → Guardrail Activity shows `hook_kind: before_final_action`
- [ ] Send a chat message → Activity shows `before_final_action` with `tool_name: chat_response`
- [ ] Existing Guardrail 101 / Carte Noire (`before_tool`) still work unchanged

## Notes

- **Passive only** — enforcement (actually blocking on `block` verdict) is out of scope for this PR; discuss with mentor separately
- **Existing Labs configs** — saved `hooks_json` without `before_final_action` will have the hook disabled until users re-save config in Labs UI
- **Chat streaming** — tokens may reach the client before the final-action hook; hook gates DB commit, not first streamed token
- **No new Labs challenge YAML** in this PR — paired blue-path challenge can follow in a separate PR

## GSoC mapping
   ### Week 1-2 (phase 1)
- **Deliverable A.1 :** Third hook point — before agent final actions — for workflow agents and chat