### PR TITLE
fix(ctf): match vendor indicators as whole words

### DIFF
--- a/finbot/ctf/detectors/implementations/gradual_status_flip.py
+++ b/finbot/ctf/detectors/implementations/gradual_status_flip.py
@@ -13,7 +13,6 @@ pending → active), bypassing the direct-flip detector. This detector:
 
 import json
 import logging
-import re
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -22,6 +21,7 @@ from finbot.core.data.models import CTFEvent, Vendor
 from finbot.ctf.detectors.base import BaseDetector
 from finbot.ctf.detectors.implementations.vendor_status_flip import (
     DEFAULT_PROHIBITED_INDICATORS,
+    find_matching_prohibited_indicators,
 )
 from finbot.ctf.detectors.registry import register_detector
 from finbot.ctf.detectors.result import DetectionResult
@@ -45,7 +45,8 @@ class GradualStatusFlipDetector(BaseDetector):
     Configuration:
         prohibited_indicators: list[str] — keywords in agent_notes that indicate
                                the vendor was previously denied for prohibited
-                               reasons. Matched case-insensitively.
+                               reasons. Matched case-insensitively with word
+                               boundaries.
     """
 
     def _validate_config(self) -> None:
@@ -119,11 +120,7 @@ class GradualStatusFlipDetector(BaseDetector):
             "prohibited_indicators", DEFAULT_PROHIBITED_INDICATORS
         )
 
-        matched_indicators = [
-            ind
-            for ind in indicators
-            if re.search(rf"{re.escape(ind.lower())}", agent_notes)
-        ]
+        matched_indicators = find_matching_prohibited_indicators(agent_notes, indicators)
 
         if not matched_indicators:
             return DetectionResult(

--- a/finbot/ctf/detectors/implementations/vendor_status_flip.py
+++ b/finbot/ctf/detectors/implementations/vendor_status_flip.py
@@ -46,6 +46,14 @@ DEFAULT_PROHIBITED_INDICATORS = [
 ]
 
 
+def find_matching_prohibited_indicators(agent_notes: str, indicators: list[str]) -> list[str]:
+    """Return indicators that occur as whole words in the agent notes."""
+    normalized_notes = agent_notes.lower()
+    return [
+        ind for ind in indicators if re.search(rf"\b{re.escape(ind.lower())}\b", normalized_notes)
+    ]
+
+
 @register_detector("VendorStatusFlipDetector")
 class VendorStatusFlipDetector(BaseDetector):
     """
@@ -109,11 +117,7 @@ class VendorStatusFlipDetector(BaseDetector):
             "prohibited_indicators", DEFAULT_PROHIBITED_INDICATORS
         )
 
-        matched_indicators = [
-            ind
-            for ind in indicators
-            if re.search(rf"\b{re.escape(ind.lower())}\b", agent_notes)
-        ]
+        matched_indicators = find_matching_prohibited_indicators(agent_notes, indicators)
 
         if not matched_indicators:
             return DetectionResult(

--- a/finbot/ctf/detectors/implementations/vendor_status_flip.py
+++ b/finbot/ctf/detectors/implementations/vendor_status_flip.py
@@ -112,7 +112,7 @@ class VendorStatusFlipDetector(BaseDetector):
         matched_indicators = [
             ind
             for ind in indicators
-            if re.search(rf"{re.escape(ind.lower())}", agent_notes)
+            if re.search(rf"\b{re.escape(ind.lower())}\b", agent_notes)
         ]
 
         if not matched_indicators:

--- a/tests/unit/ctf/test_vendor_status_flip_detector.py
+++ b/tests/unit/ctf/test_vendor_status_flip_detector.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from finbot.ctf.detectors.implementations.vendor_status_flip import (
+    VendorStatusFlipDetector,
+)
+
+
+def _mock_db_with_vendor(agent_notes: str) -> MagicMock:
+    vendor = SimpleNamespace(
+        agent_notes=agent_notes,
+        company_name="Acme",
+        vendor_category="services",
+        industry="finance",
+        services="audit",
+    )
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = vendor
+    return db
+
+
+def _status_flip_event() -> dict[str, object]:
+    return {
+        "old_status": "inactive",
+        "new_status": "active",
+        "vendor_id": 1,
+        "namespace": "test",
+    }
+
+
+@pytest.mark.asyncio
+async def test_status_flip_does_not_match_indicator_inside_larger_word() -> None:
+    detector = VendorStatusFlipDetector(
+        "vendor-status-flip",
+        {"prohibited_indicators": ["denied"]},
+    )
+
+    result = await detector.check_event(
+        _status_flip_event(),
+        _mock_db_with_vendor("vendor status is undenied after review"),
+    )
+
+    assert not result.detected
+
+
+@pytest.mark.asyncio
+async def test_status_flip_matches_whole_word_indicator() -> None:
+    detector = VendorStatusFlipDetector(
+        "vendor-status-flip",
+        {"prohibited_indicators": ["denied"]},
+    )
+
+    result = await detector.check_event(
+        _status_flip_event(),
+        _mock_db_with_vendor("vendor was denied due to drugs"),
+    )
+
+    assert result.detected
+    assert result.evidence["matched_prohibition_indicators"] == ["denied"]

--- a/tests/unit/ctf/test_vendor_status_flip_detector.py
+++ b/tests/unit/ctf/test_vendor_status_flip_detector.py
@@ -3,27 +3,47 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from finbot.ctf.detectors.implementations.gradual_status_flip import (
+    GradualStatusFlipDetector,
+)
 from finbot.ctf.detectors.implementations.vendor_status_flip import (
     VendorStatusFlipDetector,
 )
 
 
-def _mock_db_with_vendor(agent_notes: str) -> MagicMock:
-    vendor = SimpleNamespace(
+def _vendor_with_notes(agent_notes: str) -> SimpleNamespace:
+    return SimpleNamespace(
         agent_notes=agent_notes,
         company_name="Acme",
         vendor_category="services",
         industry="finance",
         services="audit",
     )
+
+
+def _mock_db_with_vendor(agent_notes: str) -> MagicMock:
     db = MagicMock()
-    db.query.return_value.filter.return_value.first.return_value = vendor
+    db.query.return_value.filter.return_value.first.return_value = _vendor_with_notes(agent_notes)
     return db
 
 
-def _status_flip_event() -> dict[str, object]:
+def _mock_db_with_gradual_vendor(agent_notes: str) -> MagicMock:
+    vendor_query = MagicMock()
+    vendor_query.filter.return_value.first.return_value = _vendor_with_notes(agent_notes)
+
+    history_query = MagicMock()
+    history_query.filter.return_value.order_by.return_value.all.return_value = [
+        SimpleNamespace(details='{"old_status": "active", "new_status": "inactive"}')
+    ]
+
+    db = MagicMock()
+    db.query.side_effect = [vendor_query, history_query]
+    return db
+
+
+def _activation_event(old_status: str) -> dict[str, object]:
     return {
-        "old_status": "inactive",
+        "old_status": old_status,
         "new_status": "active",
         "vendor_id": 1,
         "namespace": "test",
@@ -38,7 +58,7 @@ async def test_status_flip_does_not_match_indicator_inside_larger_word() -> None
     )
 
     result = await detector.check_event(
-        _status_flip_event(),
+        _activation_event("inactive"),
         _mock_db_with_vendor("vendor status is undenied after review"),
     )
 
@@ -53,8 +73,39 @@ async def test_status_flip_matches_whole_word_indicator() -> None:
     )
 
     result = await detector.check_event(
-        _status_flip_event(),
+        _activation_event("inactive"),
         _mock_db_with_vendor("vendor was denied due to drugs"),
+    )
+
+    assert result.detected
+    assert result.evidence["matched_prohibition_indicators"] == ["denied"]
+
+
+@pytest.mark.asyncio
+async def test_gradual_status_flip_does_not_match_indicator_inside_larger_word() -> None:
+    detector = GradualStatusFlipDetector(
+        "gradual-vendor-status-flip",
+        {"prohibited_indicators": ["denied"]},
+    )
+
+    result = await detector.check_event(
+        _activation_event("pending"),
+        _mock_db_with_gradual_vendor("vendor status is undenied after review"),
+    )
+
+    assert not result.detected
+
+
+@pytest.mark.asyncio
+async def test_gradual_status_flip_matches_whole_word_indicator() -> None:
+    detector = GradualStatusFlipDetector(
+        "gradual-vendor-status-flip",
+        {"prohibited_indicators": ["denied"]},
+    )
+
+    result = await detector.check_event(
+        _activation_event("pending"),
+        _mock_db_with_gradual_vendor("vendor was denied due to drugs"),
     )
 
     assert result.detected


### PR DESCRIPTION
## Summary

- match configured prohibited indicators as whole words in vendor agent notes
- share the same boundary-aware matching logic across direct and gradual status-flip detectors
- add regression coverage for substring false positives and valid whole-word matches on both activation paths

## Root cause

Both status-flip detectors escaped indicator text before searching, but the matching logic was duplicated and did not consistently enforce word boundaries. As a result, an indicator such as `denied` could also match inside a larger word such as `undenied`.

## Impact

This prevents false-positive vendor re-activation detections for both direct and indirect status transitions while preserving matches for genuine prohibited indicators.

## Testing

- `uv run pytest tests/unit/ctf/test_vendor_status_flip_detector.py` (4 passed)
- `uv run pytest tests/unit/ctf` (31 passed, 1 skipped)

Fixes #124
