### PR TITLE
fix(finmail): cap email recipient count

### DIFF
--- a/finbot/mcp/servers/finmail/routing.py
+++ b/finbot/mcp/servers/finmail/routing.py
@@ -17,6 +17,8 @@ from finbot.mcp.servers.finmail.repositories import EmailRepository
 
 logger = logging.getLogger(__name__)
 
+MAX_RECIPIENTS = 20
+
 
 def get_admin_address(namespace: str) -> str:
     """Derive the canonical admin address from a namespace."""
@@ -67,6 +69,11 @@ def route_and_deliver(
 
     Returns a delivery summary with the list of deliveries and counts.
     """
+    recipient_count = sum(len(addresses or []) for addresses in (to, cc, bcc))
+    if recipient_count > MAX_RECIPIENTS:
+        error = f"Recipient count {recipient_count} exceeds maximum of {MAX_RECIPIENTS}"
+        return {"error": error}
+
     to_json = json.dumps(to) if to else None
     cc_json = json.dumps(cc) if cc else None
     bcc_json = json.dumps(bcc) if bcc else None

--- a/tests/unit/mcp/test_finmail_routing.py
+++ b/tests/unit/mcp/test_finmail_routing.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock
+
+from finbot.mcp.servers.finmail.routing import MAX_RECIPIENTS, route_and_deliver
+
+
+def _route_email(
+    to: list[str],
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+) -> tuple[dict, MagicMock, MagicMock]:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    repo = MagicMock()
+
+    result = route_and_deliver(
+        db=db,
+        repo=repo,
+        namespace="test",
+        to=to,
+        subject="Recipient limit test",
+        body="Test body",
+        cc=cc,
+        bcc=bcc,
+    )
+    return result, db, repo
+
+
+def test_route_and_deliver_rejects_recipient_count_above_limit() -> None:
+    recipients = [f"recipient-{index}@example.com" for index in range(100)]
+
+    result, db, repo = _route_email(to=recipients)
+
+    assert result == {"error": f"Recipient count 100 exceeds maximum of {MAX_RECIPIENTS}"}
+    db.query.assert_not_called()
+    repo.create_email.assert_not_called()
+
+
+def test_route_and_deliver_counts_to_cc_and_bcc_together() -> None:
+    to = [f"to-{index}@example.com" for index in range(10)]
+    cc = [f"cc-{index}@example.com" for index in range(10)]
+    bcc = ["bcc@example.com"]
+
+    result, db, repo = _route_email(to=to, cc=cc, bcc=bcc)
+
+    assert result == {"error": f"Recipient count 21 exceeds maximum of {MAX_RECIPIENTS}"}
+    db.query.assert_not_called()
+    repo.create_email.assert_not_called()
+
+
+def test_route_and_deliver_allows_recipient_count_at_limit() -> None:
+    recipients = [f"recipient-{index}@test.finbot" for index in range(MAX_RECIPIENTS)]
+
+    result, _, repo = _route_email(to=recipients)
+
+    assert result["sent"] is True
+    assert len(result["deliveries"]) == MAX_RECIPIENTS
+    assert result["delivery_count"] == MAX_RECIPIENTS
+    assert repo.create_email.call_count == MAX_RECIPIENTS


### PR DESCRIPTION
## Summary

- cap FinMail delivery at 20 recipients across the combined `to`, `cc`, and `bcc` lists
- reject oversized messages before serialization, vendor lookups, or email inserts
- add regression coverage for oversized, aggregate-list, and exact-boundary behavior

## Root cause

`route_and_deliver` iterated over every supplied recipient without enforcing an upper bound, allowing a single request to trigger an arbitrary number of database lookups and inserts.

## Testing

- `uv run pytest tests/unit/mcp`
- `uv run black --check tests/unit/mcp/test_finmail_routing.py`
- `uv run isort --check-only finbot/mcp/servers/finmail/routing.py tests/unit/mcp/test_finmail_routing.py`

Fixes #346
