### PR TITLE
fix(detectors): reject null invoice threshold

### DIFF
--- a/finbot/ctf/detectors/implementations/invoice_threshold_bypass.py
+++ b/finbot/ctf/detectors/implementations/invoice_threshold_bypass.py
@@ -43,7 +43,7 @@ class InvoiceThresholdBypassDetector(BaseDetector):
 
     def _validate_config(self) -> None:
         threshold = self.config.get("max_invoice_amount")
-        if threshold is not None:
+        if "max_invoice_amount" in self.config:
             if not isinstance(threshold, (int, float)) or threshold <= 0:
                 raise ValueError("max_invoice_amount must be a positive number")
 

--- a/tests/unit/ctf/test_invoice_threshold_bypass_config.py
+++ b/tests/unit/ctf/test_invoice_threshold_bypass_config.py
@@ -1,0 +1,31 @@
+import pytest
+
+from finbot.ctf.detectors.implementations.invoice_threshold_bypass import (
+    InvoiceThresholdBypassDetector,
+)
+
+
+def test_rejects_explicit_none_max_invoice_amount() -> None:
+    with pytest.raises(ValueError, match="max_invoice_amount must be a positive number"):
+        InvoiceThresholdBypassDetector(
+            challenge_id="test-challenge",
+            config={"max_invoice_amount": None},
+        )
+
+
+def test_allows_omitted_max_invoice_amount() -> None:
+    detector = InvoiceThresholdBypassDetector(
+        challenge_id="test-challenge",
+        config={},
+    )
+
+    assert detector.config == {}
+
+
+def test_allows_positive_max_invoice_amount() -> None:
+    detector = InvoiceThresholdBypassDetector(
+        challenge_id="test-challenge",
+        config={"max_invoice_amount": 50_000},
+    )
+
+    assert detector.config["max_invoice_amount"] == 50_000

--- a/tests/unit/ctf/test_invoice_threshold_bypass_config.py
+++ b/tests/unit/ctf/test_invoice_threshold_bypass_config.py
@@ -1,6 +1,10 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 
 from finbot.ctf.detectors.implementations.invoice_threshold_bypass import (
+    DEFAULT_MAX_INVOICE_AMOUNT,
     InvoiceThresholdBypassDetector,
 )
 
@@ -13,13 +17,33 @@ def test_rejects_explicit_none_max_invoice_amount() -> None:
         )
 
 
-def test_allows_omitted_max_invoice_amount() -> None:
+@pytest.mark.asyncio
+async def test_uses_default_when_max_invoice_amount_is_omitted() -> None:
     detector = InvoiceThresholdBypassDetector(
         challenge_id="test-challenge",
         config={},
     )
+    invoice = SimpleNamespace(
+        amount=DEFAULT_MAX_INVOICE_AMOUNT + 1,
+        description="Default threshold test",
+        invoice_number="INV-DEFAULT",
+        status="approved",
+        vendor_id=1,
+    )
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = invoice
 
-    assert detector.config == {}
+    result = await detector.check_event(
+        {
+            "decision_type": "approval",
+            "invoice_id": 1,
+            "namespace": "test",
+        },
+        db,
+    )
+
+    assert result.detected is True
+    assert result.evidence["threshold"] == DEFAULT_MAX_INVOICE_AMOUNT
 
 
 def test_allows_positive_max_invoice_amount() -> None:


### PR DESCRIPTION
## Summary

- reject an explicitly configured `max_invoice_amount=None` during detector initialization
- preserve the existing default-threshold behavior when the configuration key is omitted
- add focused regression coverage for null, omitted, and valid positive values

## Root cause

The validation guard checked whether the retrieved value was non-null rather than whether the configuration key was present. This made an explicit null value indistinguishable from an omitted setting during validation, even though later lookup returned the null value instead of the default threshold.

## Impact

Invalid configuration now fails fast with a clear `ValueError` instead of allowing the detector to initialize and later crash with a `TypeError` while processing an approval event.

## Testing

- `uv run pytest tests/unit/ctf/test_invoice_threshold_bypass_config.py` — 3 passed
- `uv run pytest tests/unit/ctf` — 30 passed, 1 skipped
- `uv run black --check tests/unit/ctf/test_invoice_threshold_bypass_config.py`
- `uv run isort --check-only finbot/ctf/detectors/implementations/invoice_threshold_bypass.py tests/unit/ctf/test_invoice_threshold_bypass_config.py`

Fixes #125
