### PR TITLE
fix(detectors): reject null trust threshold

### DIFF
--- a/finbot/ctf/detectors/implementations/invoice_trust_override.py
+++ b/finbot/ctf/detectors/implementations/invoice_trust_override.py
@@ -46,7 +46,7 @@ class InvoiceTrustOverrideDetector(BaseDetector):
 
     def _validate_config(self) -> None:
         min_amount = self.config.get("min_amount")
-        if min_amount is not None:
+        if "min_amount" in self.config:
             if not isinstance(min_amount, (int, float)) or min_amount <= 0:
                 raise ValueError("min_amount must be a positive number")
 

--- a/tests/unit/ctf/test_invoice_trust_override_config.py
+++ b/tests/unit/ctf/test_invoice_trust_override_config.py
@@ -1,6 +1,10 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 
 from finbot.ctf.detectors.implementations.invoice_trust_override import (
+    DEFAULT_MIN_AMOUNT,
     InvoiceTrustOverrideDetector,
 )
 
@@ -13,13 +17,42 @@ def test_rejects_explicit_none_min_amount() -> None:
         )
 
 
-def test_allows_omitted_min_amount() -> None:
+@pytest.mark.asyncio
+async def test_uses_default_when_min_amount_is_omitted() -> None:
     detector = InvoiceTrustOverrideDetector(
         challenge_id="test-challenge",
         config={},
     )
+    invoice = SimpleNamespace(
+        amount=DEFAULT_MIN_AMOUNT,
+        description="Default threshold test",
+        invoice_number="INV-DEFAULT",
+        status="approved",
+        vendor_id=1,
+    )
+    vendor = SimpleNamespace(
+        company_name="Low Trust Vendor",
+        id=1,
+        trust_level="low",
+    )
+    invoice_query = MagicMock()
+    invoice_query.filter.return_value.first.return_value = invoice
+    vendor_query = MagicMock()
+    vendor_query.filter.return_value.first.return_value = vendor
+    db = MagicMock()
+    db.query.side_effect = [invoice_query, vendor_query]
 
-    assert detector.config == {}
+    result = await detector.check_event(
+        {
+            "decision_type": "approval",
+            "invoice_id": 1,
+            "namespace": "test",
+        },
+        db,
+    )
+
+    assert result.detected is True
+    assert result.evidence["min_amount_threshold"] == DEFAULT_MIN_AMOUNT
 
 
 def test_allows_positive_min_amount() -> None:

--- a/tests/unit/ctf/test_invoice_trust_override_config.py
+++ b/tests/unit/ctf/test_invoice_trust_override_config.py
@@ -1,0 +1,31 @@
+import pytest
+
+from finbot.ctf.detectors.implementations.invoice_trust_override import (
+    InvoiceTrustOverrideDetector,
+)
+
+
+def test_rejects_explicit_none_min_amount() -> None:
+    with pytest.raises(ValueError, match="min_amount must be a positive number"):
+        InvoiceTrustOverrideDetector(
+            challenge_id="test-challenge",
+            config={"min_amount": None},
+        )
+
+
+def test_allows_omitted_min_amount() -> None:
+    detector = InvoiceTrustOverrideDetector(
+        challenge_id="test-challenge",
+        config={},
+    )
+
+    assert detector.config == {}
+
+
+def test_allows_positive_min_amount() -> None:
+    detector = InvoiceTrustOverrideDetector(
+        challenge_id="test-challenge",
+        config={"min_amount": 10_000},
+    )
+
+    assert detector.config["min_amount"] == 10_000


### PR DESCRIPTION
## Summary

- reject an explicitly configured `min_amount=None` during detector initialization
- preserve the existing default-threshold behavior when the configuration key is omitted
- add focused regression coverage for null, omitted, and valid positive values

## Root cause

The validation guard checked whether the retrieved value was non-null rather than whether the configuration key was present. This made an explicit null value indistinguishable from an omitted setting during validation, even though later lookup returned the null value instead of the default threshold.

## Impact

Invalid configuration now fails fast with a clear `ValueError` instead of allowing the detector to initialize and later crash with a `TypeError` while processing a qualifying approval event.

## Testing

- `uv run pytest tests/unit/ctf/test_invoice_trust_override_config.py` — 3 passed
- `uv run pytest tests/unit/ctf` — 30 passed, 1 skipped
- `uv run black --check tests/unit/ctf/test_invoice_trust_override_config.py`
- `uv run isort --check-only finbot/ctf/detectors/implementations/invoice_trust_override.py tests/unit/ctf/test_invoice_trust_override_config.py`

Fixes #126
