### PR TITLE
fix(data): raise clear error instead of crashing on missing invoice dates

### DIFF
--- a/finbot/core/data/models.py
+++ b/finbot/core/data/models.py
@@ -397,6 +397,11 @@ class Invoice(Base):
             except (ValueError, TypeError):
                 pass
 
+        if self.invoice_date is None:
+            raise ValueError(f"Invoice {self.id} has no invoice_date set")
+        if self.due_date is None:
+            raise ValueError(f"Invoice {self.id} has no due_date set")
+
         return {
             "id": self.id,
             "namespace": self.namespace,

--- a/tests/unit/data/test_invoice_model.py
+++ b/tests/unit/data/test_invoice_model.py
@@ -1,0 +1,70 @@
+"""Tests for Invoice.to_dict's date-field null handling.
+
+GitHub issues #290 (Bug_107, PAY-FIELD-001) and #291 (Bug_108,
+PAY-FIELD-002): Invoice.to_dict calls .isoformat() directly on
+invoice_date and due_date with no null guard, so a row with either field
+missing raises an unhandled AttributeError instead of a clear error --
+and since get_invoice_for_payment (finbot/tools/data/payment.py) calls
+to_dict() directly, the crash propagates straight into payment
+processing with no useful diagnostic.
+
+Verified against source before writing anything: finbot/core/data/
+models.py's Invoice.to_dict (lines ~391-414) has no guard on either
+field. Both columns are declared nullable=False in the schema, so this
+is only reachable via corrupted/anomalous data (e.g. a raw SQL write
+bypassing the ORM) -- but when it happens, the fix should raise a clear,
+diagnosable ValueError rather than crash with an opaque AttributeError,
+per the issues' own acceptance criteria.
+"""
+
+import pytest
+from datetime import UTC, datetime
+
+from finbot.core.data.models import Invoice
+
+
+def _make_invoice(invoice_date, due_date):
+    now = datetime.now(UTC)
+    return Invoice(
+        id=1,
+        namespace="ns_test",
+        vendor_id=1,
+        invoice_number="1",
+        amount=100.0,
+        description="test invoice",
+        invoice_date=invoice_date,
+        due_date=due_date,
+        status="approved",
+        agent_notes=None,
+        attachments=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestInvoiceToDictDateHandling:
+
+    @pytest.mark.unit
+    def test_pay_field_001_to_dict_raises_clear_error_when_invoice_date_is_none(self):
+        invoice = _make_invoice(invoice_date=None, due_date=datetime.now(UTC))
+
+        with pytest.raises(ValueError, match="invoice_date"):
+            invoice.to_dict()
+
+    @pytest.mark.unit
+    def test_pay_field_002_to_dict_raises_clear_error_when_due_date_is_none(self):
+        invoice = _make_invoice(invoice_date=datetime.now(UTC), due_date=None)
+
+        with pytest.raises(ValueError, match="due_date"):
+            invoice.to_dict()
+
+    @pytest.mark.unit
+    def test_to_dict_works_normally_when_both_dates_present(self):
+        """Regression: ordinary invoices with valid dates must be unaffected."""
+        now = datetime.now(UTC)
+        invoice = _make_invoice(invoice_date=now, due_date=now)
+
+        result = invoice.to_dict()
+
+        assert result["invoice_date"] == now.isoformat().replace("+00:00", "Z")
+        assert result["due_date"] == now.isoformat().replace("+00:00", "Z")


### PR DESCRIPTION
## Summary

Fixes #290, fixes #291.

`Invoice.to_dict()` calls `.isoformat()` directly on `invoice_date` and `due_date` with no null guard. Both columns are `NOT NULL` in the schema, so this is only reachable via corrupted or anomalous data (e.g. a raw SQL write bypassing the ORM constraint) — but when it happens, it crashed with an opaque `AttributeError: 'NoneType' object has no attribute 'isoformat'` instead of a diagnosable error. Since `get_invoice_for_payment` (`finbot/tools/data/payment.py`) calls `to_dict()` directly, the crash propagated straight into payment processing with no useful message.

## Fix

Raises a clear `ValueError` naming the invoice ID and the specific missing field, instead of crashing with an unhandled `AttributeError`. Checked that no code anywhere in the codebase catches `AttributeError` around a `to_dict()` call, so nothing depends on the old crash type/behavior.

## Comparison against another open fix for the same issue

Another contributor has an independent, already-open PR (#293) for the same two issues. Worth comparing openly since both are unmerged:

Both issues' own **Expected behavior** and **Acceptance criteria** explicitly say: *"ValueError raised with a meaningful message"* / *"test_pay_field_001 raises ValueError, not AttributeError."* This PR does exactly that. PR #293 takes a different approach — it returns `None` for the missing field instead of raising anything, so the invoice silently serializes with a missing date and flows onward into payment processing rather than surfacing as an error.

That's not necessarily wrong as a general design choice, but it doesn't satisfy what the linked issues themselves ask for, and for a payment pipeline specifically, a loud, diagnosable failure on corrupted data seems safer than a quiet one — silently treating "date field missing" as normal risks masking a real data-integrity problem rather than surfacing it for review. Flagging this for whoever merges, not to relitigate #293, just so the choice between the two approaches is visible.

## Test plan

- [x] New test file `tests/unit/data/test_invoice_model.py` — reproduces both crashes first (confirmed failing against the unfixed code, exact `AttributeError` matching both issue reports), then confirms the fix
- [x] Regression test confirms invoices with valid dates are completely unaffected
- [x] `pytest tests/unit/data/test_invoice_model.py` — 3/3 passing