### PR TITLE
Fix: DNS-based SSRF bypass in guardrail webhook URL validation

### DIFF
--- a/finbot/apps/labs/routes/guardrails.py
+++ b/finbot/apps/labs/routes/guardrails.py
@@ -3,7 +3,10 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from finbot.core.auth.middleware import get_session_context
+from finbot.core.auth.middleware import (
+    get_authenticated_session_context,
+    get_session_context,
+)
 from finbot.core.auth.session import SessionContext
 from finbot.core.data.database import db_session
 from finbot.core.data.repositories import (
@@ -61,7 +64,7 @@ async def get_guardrail_config(
 @router.put("", response_model=GuardrailConfigResponse, status_code=200)
 async def upsert_guardrail_config(
     body: GuardrailConfigRequest,
-    session_context: SessionContext = Depends(get_session_context),
+    session_context: SessionContext = Depends(get_authenticated_session_context),
 ):
     """Create or update the guardrail webhook configuration."""
     # Validated here first, off the event loop with a bounded timeout --
@@ -94,7 +97,7 @@ async def upsert_guardrail_config(
 
 @router.post("/toggle", response_model=GuardrailConfigResponse)
 async def toggle_guardrail_enabled(
-    session_context: SessionContext = Depends(get_session_context),
+    session_context: SessionContext = Depends(get_authenticated_session_context),
 ):
     """Toggle the enabled flag on the guardrail config."""
     with db_session() as db:
@@ -111,7 +114,7 @@ async def toggle_guardrail_enabled(
 
 @router.post("/rotate-secret", response_model=GuardrailConfigResponse)
 async def rotate_signing_secret(
-    session_context: SessionContext = Depends(get_session_context),
+    session_context: SessionContext = Depends(get_authenticated_session_context),
 ):
     """Rotate the HMAC signing secret."""
     with db_session() as db:
@@ -128,7 +131,7 @@ async def rotate_signing_secret(
 
 @router.delete("", status_code=204)
 async def delete_guardrail_config(
-    session_context: SessionContext = Depends(get_session_context),
+    session_context: SessionContext = Depends(get_authenticated_session_context),
 ):
     """Delete the guardrail webhook configuration."""
     with db_session() as db:
@@ -142,7 +145,7 @@ async def delete_guardrail_config(
 
 @router.post("/test")
 async def test_webhook_delivery(
-    session_context: SessionContext = Depends(get_session_context),
+    session_context: SessionContext = Depends(get_authenticated_session_context),
 ):
     """Send a test before_tool hook to the user's webhook and return the result."""
     svc = GuardrailHookService(

--- a/finbot/apps/labs/routes/guardrails.py
+++ b/finbot/apps/labs/routes/guardrails.py
@@ -9,6 +9,7 @@ from finbot.core.data.database import db_session
 from finbot.core.data.repositories import (
     CTFEventRepository,
     LabsGuardrailConfigRepository,
+    validate_webhook_url_async,
 )
 from finbot.guardrails.schemas import HookKind
 from finbot.guardrails.service import GuardrailHookService
@@ -63,6 +64,16 @@ async def upsert_guardrail_config(
     session_context: SessionContext = Depends(get_session_context),
 ):
     """Create or update the guardrail webhook configuration."""
+    # Validated here first, off the event loop with a bounded timeout --
+    # validate_webhook_url can perform a real DNS lookup, which is a
+    # synchronous, unbounded call with no built-in timeout. repo.upsert()
+    # is told to skip its own internal check below: re-running it would be
+    # a second, unbounded DNS resolution while holding an open DB session,
+    # which is worse than what we're fixing, not better.
+    valid, err = await validate_webhook_url_async(body.webhook_url)
+    if not valid:
+        raise HTTPException(status_code=422, detail=err)
+
     with db_session() as db:
         repo = LabsGuardrailConfigRepository(db, session_context)
         try:
@@ -71,6 +82,7 @@ async def upsert_guardrail_config(
                 hooks=body.hooks,
                 timeout_seconds=body.timeout_seconds,
                 enabled=body.enabled,
+                skip_url_validation=True,
             )
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/finbot/core/data/repositories.py
+++ b/finbot/core/data/repositories.py
@@ -1,8 +1,10 @@
 """Data Repositories for FinBot CTF Platform"""
 
+import asyncio
 import ipaddress
 import json
 import secrets
+import socket
 from datetime import UTC, datetime
 from urllib.parse import urlparse
 
@@ -1287,11 +1289,54 @@ _BLOCKED_NETWORKS = [
     ipaddress.ip_network("172.16.0.0/12"),
     ipaddress.ip_network("192.168.0.0/16"),
     ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),  # RFC 6598 carrier-grade NAT -- used by
+    # several cloud providers for internal-only service traffic.
     ipaddress.ip_network("0.0.0.0/8"),
     ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("::/128"),  # unspecified IPv6; connect() to it behaves like
+    # loopback on some stacks, same reasoning as blocking 0.0.0.0/8 above.
     ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
 ]
+
+# Known, accepted gap: the deprecated IPv4-compatible IPv6 form (::127.0.0.1,
+# distinct from the IPv4-*mapped* ::ffff:127.0.0.1 form handled below) and the
+# NAT64 well-known prefix (64:ff9b::/96, which can embed an IPv4 address) are
+# not unwrapped here. Real-world exploitability is low -- the deprecated form
+# isn't routed by most modern kernels, and NAT64 requires the deployment to
+# actually run a NAT64 gateway -- but note it if extending this further.
+
+
+def _blocked_network_hit(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+    return any(addr in net for net in _BLOCKED_NETWORKS)
+
+
+def _hostname_resolves_to_blocked_address(hostname: str) -> str | None:
+    """Resolve hostname and check every returned address against
+    _BLOCKED_NETWORKS -- not just a literal IP typed directly into the URL.
+    Returns an error message if blocked/unresolvable, else None.
+
+    This catches DNS-based SSRF: a hostname that isn't itself an IP literal
+    but resolves to a loopback/private/link-local address (e.g. a domain an
+    attacker controls the DNS for, pointed at 127.0.0.1 or the cloud
+    metadata endpoint 169.254.169.254).
+    """
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+    except (socket.gaierror, OSError, UnicodeError):
+        # gaierror/OSError: resolution failure. UnicodeError: malformed
+        # hostname (e.g. an overlong label the idna codec rejects) --
+        # confirmed socket.getaddrinfo raises UnicodeEncodeError, not
+        # gaierror, for that case.
+        return f"Could not resolve hostname '{hostname}'"
+
+    for _family, _type, _proto, _canonname, sockaddr in addrinfo:
+        addr = ipaddress.ip_address(sockaddr[0])
+        if _blocked_network_hit(addr):
+            return f"Hostname '{hostname}' resolves to a blocked address ({sockaddr[0]})"
+    return None
 
 
 def validate_webhook_url(url: str) -> tuple[bool, str | None]:
@@ -1329,11 +1374,16 @@ def validate_webhook_url(url: str) -> tuple[bool, str | None]:
 
         try:
             addr = ipaddress.ip_address(hostname)
-            for net in _BLOCKED_NETWORKS:
-                if addr in net:
-                    return False, f"IP address {hostname} is in a blocked range"
         except ValueError:
-            pass
+            # Not a literal IP -- resolve it and check every address it
+            # points at, so a hostname can't be used to bypass the check
+            # a bare IP literal would have failed.
+            err = _hostname_resolves_to_blocked_address(hostname)
+            if err:
+                return False, err
+        else:
+            if _blocked_network_hit(addr):
+                return False, f"IP address {hostname} is in a blocked range"
 
     if not parsed.port and parsed.scheme == "https":
         pass
@@ -1343,6 +1393,33 @@ def validate_webhook_url(url: str) -> tuple[bool, str | None]:
         return False, f"Port {parsed.port} is not in the allowed range (1024-65535)"
 
     return True, None
+
+
+_WEBHOOK_VALIDATION_TIMEOUT_SECONDS = 2.0
+
+
+async def validate_webhook_url_async(
+    url: str, *, timeout: float = _WEBHOOK_VALIDATION_TIMEOUT_SECONDS
+) -> tuple[bool, str | None]:
+    """Async wrapper around validate_webhook_url for use from async call sites.
+
+    validate_webhook_url can perform a real DNS lookup (socket.getaddrinfo),
+    which is a synchronous, unbounded call with no built-in per-call timeout
+    in the stdlib. Called directly from an async context, a slow or
+    non-responding attacker-controlled DNS server would block the entire
+    event loop -- not just the caller's own request, every concurrent
+    session on that worker -- for as long as the OS resolver takes to give
+    up (often well past 30s). This offloads the check to a worker thread and
+    bounds the wait, so the event loop is freed up immediately on timeout
+    even though the worker thread itself may still be blocked on DNS in the
+    background (threads can't be forcibly killed in Python).
+    """
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(validate_webhook_url, url), timeout=timeout
+        )
+    except asyncio.TimeoutError:
+        return False, "Timed out validating webhook URL"
 
 
 # =============================================================================
@@ -1379,14 +1456,26 @@ class LabsGuardrailConfigRepository(NamespacedRepository):
         hooks: dict[str, bool] | None = None,
         timeout_seconds: int = 5,
         enabled: bool = True,
+        *,
+        skip_url_validation: bool = False,
     ) -> tuple[LabsGuardrailConfig, bool]:
         """Create or update guardrail config for the current user.
 
+        skip_url_validation: set when the caller has already validated
+        webhook_url itself (e.g. via the async pre-check in the route
+        handler, which is timeout-bounded off the event loop). Re-running
+        the synchronous check here would perform a second, unbounded DNS
+        resolution while holding an open DB session -- worse than a bare
+        blocking call, and pure redundant work for a caller that already
+        validated. Callers that have NOT already validated (any other/future
+        caller of this repository method) get the check by default.
+
         Returns (config, created) where created=True if a new row was inserted.
         """
-        valid, err = validate_webhook_url(webhook_url)
-        if not valid:
-            raise ValueError(err)
+        if not skip_url_validation:
+            valid, err = validate_webhook_url(webhook_url)
+            if not valid:
+                raise ValueError(err)
 
         if hooks is not None:
             unknown = set(hooks.keys()) - self.VALID_HOOK_KINDS

--- a/finbot/guardrails/service.py
+++ b/finbot/guardrails/service.py
@@ -19,7 +19,10 @@ from finbot.config import settings
 from finbot.core.auth.session import SessionContext
 from finbot.core.data.database import db_session
 from finbot.core.data.models import LabsGuardrailConfig
-from finbot.core.data.repositories import LabsGuardrailConfigRepository
+from finbot.core.data.repositories import (
+    LabsGuardrailConfigRepository,
+    validate_webhook_url_async,
+)
 from finbot.core.messaging import event_bus
 from finbot.guardrails.schemas import (
     HookEnvelope,
@@ -145,6 +148,14 @@ class GuardrailHookService:
         error_detail: str | None = None
 
         try:
+            # Re-validated here (not just at registration time) as a second
+            # layer against DNS rebinding: a hostname that resolved to a
+            # public address when the webhook was registered could resolve
+            # to an internal address by the time this hook actually fires.
+            valid, err = await validate_webhook_url_async(config.webhook_url)
+            if not valid:
+                raise ValueError(err)
+
             async with httpx.AsyncClient() as client:
                 resp = await client.post(
                     config.webhook_url,

--- a/tests/unit/labs/test_guardrail_config.py
+++ b/tests/unit/labs/test_guardrail_config.py
@@ -1,12 +1,24 @@
 """Tests for Labs guardrail config: SSRF validation + repository CRUD."""
 
+import socket
+from unittest.mock import patch
+
 import pytest
 
 from finbot.core.auth.session import session_manager
 from finbot.core.data.repositories import (
     LabsGuardrailConfigRepository,
     validate_webhook_url,
+    validate_webhook_url_async,
 )
+
+
+def _fake_addrinfo(*ip_strs: str):
+    """Build a socket.getaddrinfo-shaped return value for the given IPs."""
+    return [
+        (2, 1, 6, "", (ip, 443)) if ":" not in ip else (10, 1, 6, "", (ip, 443, 0, 0))
+        for ip in ip_strs
+    ]
 
 
 # =============================================================================
@@ -79,6 +91,180 @@ class TestValidateWebhookUrl:
         assert ok is False
         assert expected_fragment.lower() in err.lower()
 
+    def test_hostname_resolving_to_blocked_ip_is_rejected_in_production(self, monkeypatch):
+        """DNS-based SSRF bypass: a hostname is not itself a literal IP, so
+        the pre-fix check (ipaddress.ip_address(hostname)) would silently
+        pass it through unchecked. It must still be blocked once it
+        actually resolves to an internal address."""
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            return_value=_fake_addrinfo("127.0.0.1"),
+        ):
+            ok, err = validate_webhook_url("https://attacker-controlled.example/hook")
+        assert ok is False
+        assert "blocked" in err.lower()
+
+    def test_hostname_resolving_to_metadata_ip_is_rejected_in_production(self, monkeypatch):
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            return_value=_fake_addrinfo("169.254.169.254"),
+        ):
+            ok, err = validate_webhook_url("https://looks-legit.example/hook")
+        assert ok is False
+        assert "blocked" in err.lower()
+
+    def test_hostname_with_one_safe_and_one_unsafe_resolved_ip_is_rejected(self, monkeypatch):
+        """If ANY resolved address is unsafe, reject -- an attacker (or a
+        multi-homed/round-robin DNS setup) can control which address the
+        actual outbound request happens to use."""
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            return_value=_fake_addrinfo("8.8.8.8", "127.0.0.1"),
+        ):
+            ok, err = validate_webhook_url("https://mixed.example/hook")
+        assert ok is False
+
+    def test_hostname_resolving_to_public_ip_is_allowed_in_production(self, monkeypatch):
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            return_value=_fake_addrinfo("8.8.8.8"),
+        ):
+            ok, err = validate_webhook_url("https://real-webhook-receiver.example/hook")
+        assert ok is True
+        assert err is None
+
+    def test_unresolvable_hostname_is_rejected_in_production(self, monkeypatch):
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name or service not known"),
+        ):
+            ok, err = validate_webhook_url("https://does-not-exist.invalid/hook")
+        assert ok is False
+        assert "resolve" in err.lower()
+
+    def test_ipv4_mapped_ipv6_private_address_is_rejected_in_production(self, monkeypatch):
+        """::ffff:10.0.0.5 is IPv4-mapped IPv6 -- must unwrap and check the
+        underlying IPv4 address, not just the IPv6 shell."""
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            return_value=_fake_addrinfo("::ffff:10.0.0.5"),
+        ):
+            ok, err = validate_webhook_url("https://mapped.example/hook")
+        assert ok is False
+
+    def test_overlong_hostname_rejected_cleanly_in_production(self, monkeypatch):
+        """socket.getaddrinfo raises UnicodeEncodeError (a UnicodeError
+        subclass), not socket.gaierror, for a hostname whose label is too
+        long for the idna codec -- confirmed directly against the real
+        stdlib, not assumed. Must be rejected with a clean error, not an
+        unhandled exception."""
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        ok, err = validate_webhook_url(f"https://{'x' * 300}.example/hook")
+        assert ok is False
+        assert "resolve" in err.lower()
+
+    def test_hostname_resolution_not_triggered_in_debug_mode(self):
+        """DEBUG mode's local-testing carve-out must still short-circuit
+        before any DNS resolution happens -- no behavior change for the
+        existing, intentional local-dev workflow."""
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo"
+        ) as mock_getaddrinfo:
+            ok, err = validate_webhook_url("https://anything.example/hook")
+        assert ok is True
+        mock_getaddrinfo.assert_not_called()
+
+
+# =============================================================================
+# Async wrapper -- offloads DNS resolution off the event loop, bounded by a
+# timeout. See finbot/core/data/repositories.py:validate_webhook_url_async.
+# =============================================================================
+
+
+class TestValidateWebhookUrlAsync:
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_delegates_to_sync_validator_for_safe_url(self, monkeypatch):
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            return_value=_fake_addrinfo("8.8.8.8"),
+        ):
+            ok, err = await validate_webhook_url_async("https://real.example/hook")
+        assert ok is True
+        assert err is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_delegates_to_sync_validator_for_unsafe_url(self, monkeypatch):
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        ok, err = await validate_webhook_url_async("https://127.0.0.1/hook")
+        assert ok is False
+        assert "blocked" in err.lower()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_does_not_block_the_event_loop(self, monkeypatch):
+        """The core DoS fix: a slow resolution must not block other
+        concurrently-scheduled coroutines on the same event loop. Run a
+        slow validation alongside a trivial coroutine and confirm the
+        trivial one completes first -- proof the slow call actually ran on
+        a separate thread rather than inline on the event loop."""
+        import asyncio
+        import time
+
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+
+        def _slow_getaddrinfo(*args, **kwargs):
+            time.sleep(0.2)
+            return _fake_addrinfo("8.8.8.8")
+
+        order: list[str] = []
+
+        async def _trivial():
+            await asyncio.sleep(0)
+            order.append("trivial")
+
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            side_effect=_slow_getaddrinfo,
+        ):
+            async def _slow():
+                await validate_webhook_url_async("https://slow.example/hook")
+                order.append("slow")
+
+            await asyncio.gather(_slow(), _trivial())
+
+        assert order == ["trivial", "slow"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_times_out_on_slow_resolution(self, monkeypatch):
+        import time
+
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+
+        def _hanging_getaddrinfo(*args, **kwargs):
+            time.sleep(1.0)
+            return _fake_addrinfo("8.8.8.8")
+
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            side_effect=_hanging_getaddrinfo,
+        ):
+            ok, err = await validate_webhook_url_async(
+                "https://hangs.example/hook", timeout=0.05
+            )
+        assert ok is False
+        assert "timed out" in err.lower()
+
 
 # =============================================================================
 # Repository CRUD
@@ -126,6 +312,20 @@ class TestLabsGuardrailConfigRepository:
         monkeypatch.setattr("finbot.config.settings.DEBUG", False)
         with pytest.raises(ValueError, match="blocked range"):
             self.repo.upsert(webhook_url="https://127.0.0.1/hook")
+
+    def test_upsert_skip_url_validation_bypasses_the_check(self, monkeypatch):
+        """skip_url_validation is for callers (the route handler) that
+        already validated the URL themselves via the async, timeout-bounded
+        pre-check -- re-running the sync check here would be a second,
+        unbounded DNS resolution performed while holding an open DB
+        session. Default (skip_url_validation=False) must still validate,
+        confirmed by test_upsert_rejects_ssrf_url above."""
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+        config, created = self.repo.upsert(
+            webhook_url="https://127.0.0.1/hook", skip_url_validation=True
+        )
+        assert created is True
+        assert config.webhook_url == "https://127.0.0.1/hook"
 
     def test_upsert_rejects_unknown_hook_kinds(self):
         with pytest.raises(ValueError, match="Unknown hook kinds"):

--- a/tests/unit/labs/test_guardrail_route_security.py
+++ b/tests/unit/labs/test_guardrail_route_security.py
@@ -1,0 +1,168 @@
+"""Route-level auth tests for the Labs guardrail webhook config API.
+
+GitHub issue #535: the guardrail write endpoints (PUT, POST /toggle,
+POST /rotate-secret, DELETE, POST /test) used get_session_context, which
+accepts anonymous temporary sessions. Since the /test endpoint fires an
+immediate outbound HTTP request to whatever webhook_url is on file, an
+anonymous visitor could both register an internal URL AND trigger a
+request to it, with zero authentication -- unauthenticated SSRF.
+
+This file was not part of the original fix in this PR; it closes a real
+gap found by comparing against another contributor's independent fix
+for the same issue (PR #538), which caught the missing-auth angle that
+this PR's first pass missed (that pass only closed the DNS-resolution
+bypass inside validate_webhook_url() itself). Verified against current
+source before writing this: as of this commit, all 5 write endpoints
+still used get_session_context.
+
+Read endpoints (GET, GET /activity) intentionally stay anonymous-
+readable -- no state-changing side effect, matches this codebase's own
+convention (finbot/apps/ctf/routes/profile.py uses the same
+authenticated-vs-anonymous split between its GET and PUT).
+
+CSRF is deliberately bypassed in this file's own `client` fixture (the
+default `fast_client`/CSRFProtectionMiddleware combination rejects
+state-changing requests with a 403 before they ever reach route-level
+auth, which isn't what these tests are checking). CSRF enforcement
+itself already has its own coverage elsewhere; these tests exist to
+verify the authentication guard added by this fix, in isolation.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from finbot.core.auth.csrf import CSRFProtectionMiddleware
+from finbot.core.auth.session import session_manager
+from finbot.main import app
+
+GUARDRAILS_PREFIX = "/labs/api/v1/guardrails"
+
+
+async def _noop_csrf_dispatch(self, request: Request, call_next):
+    return await call_next(request)
+
+
+@pytest.fixture()
+def client(db):
+    with patch("finbot.main.start_processor_task", return_value=None):
+        with patch.object(CSRFProtectionMiddleware, "dispatch", new=_noop_csrf_dispatch):
+            with TestClient(app) as c:
+                yield c
+
+
+@pytest.fixture()
+def temp_session(db):
+    return session_manager.create_session()
+
+
+@pytest.fixture()
+def auth_session(db):
+    return session_manager.create_session(email="guardrail_route_test@example.com")
+
+
+@pytest.mark.unit
+class TestGuardrailWriteEndpointsRequireAuth:
+
+    def test_put_rejects_anonymous_session(self, client: TestClient, temp_session):
+        response = client.put(
+            GUARDRAILS_PREFIX,
+            json={"webhook_url": "https://example.com/hook"},
+            cookies={"finbot_session": temp_session.session_id},
+        )
+        assert response.status_code == 401
+
+    def test_toggle_rejects_anonymous_session(self, client: TestClient, temp_session):
+        response = client.post(
+            f"{GUARDRAILS_PREFIX}/toggle",
+            cookies={"finbot_session": temp_session.session_id},
+        )
+        assert response.status_code == 401
+
+    def test_rotate_secret_rejects_anonymous_session(
+        self, client: TestClient, temp_session
+    ):
+        response = client.post(
+            f"{GUARDRAILS_PREFIX}/rotate-secret",
+            cookies={"finbot_session": temp_session.session_id},
+        )
+        assert response.status_code == 401
+
+    def test_delete_rejects_anonymous_session(self, client: TestClient, temp_session):
+        response = client.delete(
+            GUARDRAILS_PREFIX,
+            cookies={"finbot_session": temp_session.session_id},
+        )
+        assert response.status_code == 401
+
+    def test_test_webhook_rejects_anonymous_session(
+        self, client: TestClient, temp_session
+    ):
+        response = client.post(
+            f"{GUARDRAILS_PREFIX}/test",
+            cookies={"finbot_session": temp_session.session_id},
+        )
+        assert response.status_code == 401
+
+
+@pytest.mark.unit
+class TestGuardrailReadEndpointsStayAnonymous:
+    """Regression: the read-only endpoints must NOT be affected by this
+    fix -- they have no state-changing side effect and anonymous
+    visitors are expected to be able to check config status."""
+
+    def test_get_config_allows_anonymous_session(self, client: TestClient, temp_session):
+        response = client.get(
+            GUARDRAILS_PREFIX,
+            cookies={"finbot_session": temp_session.session_id},
+        )
+        assert response.status_code == 200
+
+    def test_get_activity_allows_anonymous_session(
+        self, client: TestClient, temp_session
+    ):
+        response = client.get(
+            f"{GUARDRAILS_PREFIX}/activity",
+            cookies={"finbot_session": temp_session.session_id},
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.unit
+class TestGuardrailWriteEndpointsAllowAuthenticatedSession:
+    """Regression: legitimate, logged-in users must still be able to use
+    every write endpoint -- this fix must not lock out real usage."""
+
+    def test_put_allows_authenticated_session(self, client: TestClient, auth_session):
+        response = client.put(
+            GUARDRAILS_PREFIX,
+            json={"webhook_url": "https://example.com/hook"},
+            cookies={"finbot_session": auth_session.session_id},
+        )
+        assert response.status_code == 200
+
+    def test_toggle_allows_authenticated_session(self, client: TestClient, auth_session):
+        client.put(
+            GUARDRAILS_PREFIX,
+            json={"webhook_url": "https://example.com/hook"},
+            cookies={"finbot_session": auth_session.session_id},
+        )
+        response = client.post(
+            f"{GUARDRAILS_PREFIX}/toggle",
+            cookies={"finbot_session": auth_session.session_id},
+        )
+        assert response.status_code == 200
+
+    def test_delete_allows_authenticated_session(self, client: TestClient, auth_session):
+        client.put(
+            GUARDRAILS_PREFIX,
+            json={"webhook_url": "https://example.com/hook"},
+            cookies={"finbot_session": auth_session.session_id},
+        )
+        response = client.delete(
+            GUARDRAILS_PREFIX,
+            cookies={"finbot_session": auth_session.session_id},
+        )
+        assert response.status_code == 204

--- a/tests/unit/labs/test_guardrail_service.py
+++ b/tests/unit/labs/test_guardrail_service.py
@@ -149,6 +149,35 @@ class TestWebhookInvocation:
 
     @pytest.mark.asyncio
     @patch("finbot.guardrails.service.event_bus")
+    async def test_rejects_webhook_url_resolving_to_blocked_address(
+        self, mock_bus, monkeypatch
+    ):
+        """Defense-in-depth against DNS rebinding (issue #535): even a
+        webhook_url that passed validation at registration time is
+        re-checked immediately before the actual outbound request. If its
+        hostname now resolves to a blocked address, the request must never
+        be made at all."""
+        mock_bus.emit_agent_event = AsyncMock()
+        monkeypatch.setattr("finbot.config.settings.DEBUG", False)
+
+        with patch(
+            "finbot.core.data.repositories.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("127.0.0.1", 443))],
+        ), patch(
+            "httpx.AsyncClient.post", new_callable=AsyncMock
+        ) as mock_post:
+            svc = self._make_service()
+            outcome = await svc.invoke(
+                HookKind.before_tool, tool_name="approve_invoice"
+            )
+
+        mock_post.assert_not_called()
+        assert outcome == HookOutcome.error
+        call_kwargs = mock_bus.emit_agent_event.call_args.kwargs
+        assert "blocked" in call_kwargs["event_data"]["error_detail"].lower()
+
+    @pytest.mark.asyncio
+    @patch("finbot.guardrails.service.event_bus")
     async def test_block_verdict(self, mock_bus):
         mock_bus.emit_agent_event = AsyncMock()
 


### PR DESCRIPTION
## Summary

The Labs guardrail feature lets a session register a `webhook_url` that the server later POSTs to (`GuardrailHookService.invoke`, `finbot/guardrails/service.py`) during hook invocations.

A note on the linked issue first: it states there's no validation at all and suggests importing `is_ssrf_safe()` from `finbot/apps/ctf/routes/profile.py`. That function doesn't exist in the current codebase (it would come from #507, which is still open/unmerged) — worth flagging so nobody goes looking for it. There **is** existing validation already wired in: `validate_webhook_url()` in `finbot/core/data/repositories.py` is already called from `LabsGuardrailConfigRepository.upsert()` and already wrapped in a 422 response. It has its own passing test suite with an intentional, documented contract: in `DEBUG` mode (default for local dev), private/loopback addresses are allowed so contributors can test webhooks against local servers; in production (`DEBUG=False`), they're blocked via a hardcoded network list.

The actual gap: that check only ever inspected the hostname via `ipaddress.ip_address(hostname)`, which only succeeds for a bare IP literal typed directly into the URL. Any normal hostname raises `ValueError`, which was silently swallowed — so a hostname that isn't itself an IP literal but *resolves* via DNS to `127.0.0.1`, `169.254.169.254` (cloud metadata), or any RFC1918 range was never checked, in either DEBUG or production mode. That's the real, exploitable bypass this PR closes.

## Comparison against another open fix for the same issue

Another contributor has an independent, already-open PR (#538) for this same issue, and this comparison isn't a clean "ours is better" — it genuinely isn't, on its own. The two PRs found different, non-overlapping halves of the same vulnerability:

- **This PR** originally fixed only the DNS-resolution bypass in `validate_webhook_url()` above (plus a self-caught event-loop DoS, see below). It did **not** touch endpoint authentication.
- **#538** found and fixed something this PR's first pass missed entirely: all 5 write endpoints (`PUT`, `POST /toggle`, `POST /rotate-secret`, `DELETE`, `POST /test`) used `get_session_context`, which accepts anonymous temporary sessions — meaning an unauthenticated visitor could register a webhook and, via `/test`, trigger an immediate outbound request to it. That's a second, independent path into the same "unauthenticated SSRF" issue, and it was still true on `main` as of this PR's last commit before this update.

Rather than leave that gap open and just note it, I've added the authentication fix from #538's approach into this PR too (see "Also added" below), so this PR now closes both halves. Credit to #538 for finding the half this PR missed — flagging clearly rather than quietly absorbing it.

## Fix

- `validate_webhook_url()`: when the hostname isn't a literal IP, it's now resolved and every returned address is checked against the blocked-ranges list (IPv4-mapped IPv6 addresses are unwrapped first). The existing DEBUG-mode carve-out is untouched — same gating, same intentional behavior, confirmed by a new test that DNS resolution is never even triggered in DEBUG mode.
- Added `100.64.0.0/10` (RFC 6598 carrier-grade NAT, used internally by several cloud providers) and `::/128` to the blocked list.
- Fixed an uncaught `UnicodeError` on malformed/overlong hostnames (`socket.getaddrinfo` raises `UnicodeEncodeError` for those, not `socket.gaierror` — confirmed directly, not assumed).
- **DNS resolution is synchronous and unbounded**, and `invoke()` runs on every guardrail hook call. Calling it inline there would let an attacker-controlled DNS target block the event loop for every concurrent session, not just the one making the request. Added `validate_webhook_url_async()`, which offloads resolution to a worker thread via `asyncio.to_thread` bounded by `asyncio.wait_for(timeout=2s)`, and wired it into both the registration route and `invoke()` (the latter as defense-in-depth re-validation immediately before the actual request, narrowing the DNS-rebinding TOCTOU window rather than fully closing it — full closure would mean pinning the resolved IP and connecting directly to it instead of letting httpx re-resolve independently, which felt like a larger, separate change).
- `LabsGuardrailConfigRepository.upsert()` gained a `skip_url_validation` flag so the route (which now validates asynchronously first) doesn't also run the internal synchronous check redundantly — that would've meant a second, unbounded DNS resolution performed while holding an open DB session, which is worse than what this PR fixes, not better. Default behavior (no flag) is unchanged for any other caller.

## Also added: authentication on write endpoints

All 5 write endpoints now use `get_authenticated_session_context` instead of `get_session_context`, matching the pattern this codebase already uses elsewhere (`finbot/apps/ctf/routes/profile.py`'s own GET/PUT split). The 2 read-only endpoints (`GET`, `GET /activity`) stay anonymous-accessible — no state-changing side effect. 10 new tests in `test_guardrail_route_security.py` confirm all 5 write endpoints return 401 for an anonymous session, both read endpoints still allow one, and 3 endpoints still work correctly for a genuinely authenticated session.

## Review process

This went through two full review passes before opening the PR, and the first one caught a real problem in my own patch worth being upfront about: the initial version of the DNS-resolution fix called `socket.getaddrinfo` synchronously, inline, directly inside `invoke()`. Since `invoke()` fires on every guardrail hook call — a hot path, not an occasional one — that would have let an attacker register a webhook pointing at an unresponsive DNS target and freeze the entire event loop for every concurrent session on that worker, for as long as the OS resolver takes to give up (often 15-30s+). That's a self-contained HIGH-severity DoS, introduced in the course of fixing the SSRF, not present before this PR and not something I'd anticipated going in.

The `asyncio.to_thread` + `asyncio.wait_for` offload described above, the `skip_url_validation` flag, the `UnicodeError` fix, and the `test_does_not_block_the_event_loop` test that actually proves non-blocking behavior (rather than just asserting a mock was called) all came out of catching and closing that specific finding. A second review pass confirmed it was fixed correctly and surfaced no new blocking issues.

## Known residual gaps, noted rather than silently left

- The thread offload uses the process's default `ThreadPoolExecutor` (there's no dedicated pool configured anywhere in this codebase). Under sustained abuse — many concurrent registrations/invocations pointed at an unresponsive DNS target — the shared pool could still saturate, which would affect other unrelated `asyncio.to_thread`/`run_in_executor` consumers in the app. The event loop itself is genuinely protected (that was the primary risk), but a dedicated bounded executor for this specific check would close the second-order resource-exhaustion angle. Didn't want to bundle a broader executor-management change into this fix without discussion, but happy to follow up if that's wanted.
- The defense-in-depth re-check in `invoke()` narrows the DNS-rebinding window but doesn't fully close it (two independent `getaddrinfo` calls, milliseconds apart, both attacker-influenceable via a low-TTL record). Full closure needs IP-pinning (resolve once, connect to that address directly) rather than re-validating and letting httpx re-resolve on its own — scoping that as a possible follow-up rather than folding it into this PR.

## Test plan

- [x] Extended the existing `tests/unit/labs/test_guardrail_config.py::TestValidateWebhookUrl` with cases for: hostname resolving to a blocked/metadata IP, mixed safe+unsafe resolved addresses, a hostname resolving to a genuinely public IP, an unresolvable hostname, IPv4-mapped IPv6, an overlong/malformed hostname, and confirmation that DNS resolution never fires in DEBUG mode
- [x] New `TestValidateWebhookUrlAsync` class: correct delegation for safe/unsafe URLs, a timeout test, and a test that actually proves non-blocking behavior (runs a slow mocked resolution concurrently with a trivial coroutine via `asyncio.gather` and asserts the trivial one completes first)
- [x] New test for `skip_url_validation` in both directions (default still validates; explicit skip bypasses)
- [x] New test in `test_guardrail_service.py` confirming `invoke()` rejects a webhook resolving to a blocked address and never calls `httpx.AsyncClient.post`
- [x] 10 new tests in `test_guardrail_route_security.py` for the authentication fix (see above)
- [x] `pytest tests/unit/labs/ -q` — 99/99 passing
- [x] Locally merge-tested solo against fresh `origin/main`: clean
- [x] Locally merge-tested pairwise against #574, #576, #577, #578, #579, #580: clean, except a real, expected overlap with #576 — both PRs independently add a new test method at the same line in `tests/unit/labs/test_guardrail_service.py::TestWebhookInvocation` (this PR's `test_rejects_webhook_url_resolving_to_blocked_address`, #576's `test_invoke_never_raises_even_on_internal_failure`). Not a logical conflict — both tests are valid and independent, resolved by keeping both. Flagging for whoever merges second, so it's expected rather than surprising.
