### PR TITLE
Fix: guardrail payload corruption before signing + missing after_tool for complete_task

### DIFF
--- a/finbot/agents/base.py
+++ b/finbot/agents/base.py
@@ -166,6 +166,19 @@ class BaseAgent(ABC):
                                     )
                                     logger.debug("Function output: %s", function_output)
                                     if tool_call_name == "complete_task":
+                                        # Fire after_tool before returning --
+                                        # otherwise complete_task is the one
+                                        # tool call that never gets a
+                                        # matching after_tool, leaving any
+                                        # guardrail that pairs before/after
+                                        # events seeing it as open-ended.
+                                        await self._guardrail_service.invoke(
+                                            HookKind.after_tool,
+                                            tool_name=tool_call_name,
+                                            tool_source=tool_source,
+                                            tool_arguments=tool_call.get("arguments"),
+                                            tool_result=str(function_output),
+                                        )
                                         # this will end the agent loop and
                                         # return the task status and summary
                                         await self.log_task_completion(

--- a/finbot/guardrails/service.py
+++ b/finbot/guardrails/service.py
@@ -7,6 +7,7 @@ execution on the verdict.
 
 import hashlib
 import hmac
+import json
 import logging
 import time
 from datetime import UTC, datetime
@@ -29,6 +30,64 @@ from finbot.guardrails.schemas import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Fields large enough to realistically push a hook envelope over the
+# payload byte limit. Truncated in this order if the envelope is oversized.
+_TRUNCATABLE_STRING_FIELDS = ("tool_result", "user_message", "model_output")
+
+
+def _truncate_envelope_for_payload_limit(
+    envelope: HookEnvelope, max_payload: int
+) -> HookEnvelope:
+    """Return a copy of envelope with its long variable-size fields
+    truncated individually, targeting at most max_payload bytes, rather
+    than slicing the already-serialized JSON bytes.
+
+    Raw byte-slicing a serialized JSON body can cut a multi-byte UTF-8
+    character or a string/object literal in half, producing a body that
+    is neither valid UTF-8 nor valid JSON -- while an HMAC signature
+    computed over those broken bytes still "validates" fine, since the
+    receiver has no way to detect the corruption from the signature
+    alone. Truncating the Python string values themselves before
+    serialization is always safe: json.dumps re-escapes correctly no
+    matter where a string is cut -- the result is always valid JSON.
+
+    Not an absolute size guarantee: if max_payload is smaller than the
+    envelope's own fixed-field overhead (schema_version, hook_kind,
+    session_id, workflow_id, tool_name, tool_source, timestamp), the
+    returned envelope can still exceed max_payload even with every
+    truncatable field emptied. LABS_GUARDRAIL_MAX_PAYLOAD_BYTES defaults
+    to 64 KiB, far above that overhead, so this is not reachable with the
+    default config -- only with a misconfigured, unrealistically small
+    override. Still always returns valid JSON either way.
+    """
+    if len(envelope.model_dump_json().encode()) <= max_payload:
+        return envelope
+
+    truncated = envelope.model_copy()
+
+    # A dict can't be safely character-truncated without risking invalid
+    # JSON -- replace it with a small, valid marker instead. Keep the
+    # top-level key names (not values) so a receiver can still see which
+    # arguments existed, useful for correlating/auditing the call even
+    # without the actual (possibly large) values.
+    if truncated.tool_arguments is not None:
+        original_size = len(json.dumps(truncated.tool_arguments).encode())
+        truncated.tool_arguments = {
+            "_truncated": True,
+            "original_size_bytes": original_size,
+            "keys": list(truncated.tool_arguments.keys()),
+        }
+
+    for field_name in _TRUNCATABLE_STRING_FIELDS:
+        if len(truncated.model_dump_json().encode()) <= max_payload:
+            break
+        value = getattr(truncated, field_name)
+        while value and len(truncated.model_dump_json().encode()) > max_payload:
+            value = value[: len(value) // 2]
+            setattr(truncated, field_name, value)
+
+    return truncated
 
 
 class GuardrailHookService:
@@ -91,8 +150,48 @@ class GuardrailHookService:
         """Fire a passive guardrail hook.
 
         Returns the outcome for informational purposes — callers must
-        NOT branch on the outcome (execution always proceeds).
+        NOT branch on the outcome (execution always proceeds). This method
+        is guaranteed to never raise: any failure in its own plumbing
+        (config load, envelope construction, truncation, signing, or the
+        HTTP call itself) is caught and reported as HookOutcome.error, so
+        a bug or outage in guardrail delivery can never affect the
+        success/failure of the tool call or task it's observing -- callers
+        (e.g. the agent loop's own try/except around a tool call) must be
+        free to place this call wherever is natural without worrying about
+        it masking or corrupting an unrelated outcome.
         """
+        try:
+            return await self._invoke(
+                kind,
+                tool_name=tool_name,
+                tool_source=tool_source,
+                tool_arguments=tool_arguments,
+                tool_result=tool_result,
+                model=model,
+                user_message=user_message,
+                model_output=model_output,
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error(
+                "Unhandled guardrail invoke() failure: hook=%s tool=%s: %s",
+                kind.value,
+                tool_name,
+                exc,
+            )
+            return HookOutcome.error
+
+    async def _invoke(
+        self,
+        kind: HookKind,
+        *,
+        tool_name: str | None = None,
+        tool_source: str | None = None,
+        tool_arguments: dict[str, Any] | None = None,
+        tool_result: str | None = None,
+        model: str | None = None,
+        user_message: str | None = None,
+        model_output: str | None = None,
+    ) -> HookOutcome:
         if not self._is_hook_enabled(kind):
             return (
                 HookOutcome.no_config if not self._config else HookOutcome.hook_disabled
@@ -116,19 +215,20 @@ class GuardrailHookService:
             timestamp=timestamp,
         )
 
-        body_bytes = envelope.model_dump_json().encode()
-
         max_payload = settings.LABS_GUARDRAIL_MAX_PAYLOAD_BYTES
-        if len(body_bytes) > max_payload:
+        original_size = len(envelope.model_dump_json().encode())
+        was_truncated = original_size > max_payload
+        if was_truncated:
+            envelope = _truncate_envelope_for_payload_limit(envelope, max_payload)
             logger.info(
                 "guardrail payload truncated: %d -> %d bytes, hook=%s tool=%s",
-                len(body_bytes),
-                max_payload,
+                original_size,
+                len(envelope.model_dump_json().encode()),
                 kind.value,
                 tool_name,
             )
-            body_bytes = body_bytes[:max_payload]
 
+        body_bytes = envelope.model_dump_json().encode()
         signature = self._sign_payload(body_bytes, config.signing_secret, timestamp)
 
         headers = {
@@ -136,6 +236,8 @@ class GuardrailHookService:
             "X-Guardrail-Signature": signature,
             "X-Guardrail-Timestamp": timestamp,
         }
+        if was_truncated:
+            headers["X-Guardrail-Truncated"] = "true"
 
         start = time.monotonic()
         outcome: HookOutcome

--- a/tests/unit/agents/test_base_agent.py
+++ b/tests/unit/agents/test_base_agent.py
@@ -1078,4 +1078,172 @@ class TestBaseAgentFramework:
         print(f"✓ BAF-COM-001: AC3 - Errors: recovered from {len(metrics['errors'])}")
         print(f"✓ BAF-COM-001: AC4 - Tools: {len(tools)} registered")
         print(f"✓ BAF-COM-001: AC5 - process() returned success")
+
+
+# ==============================================================================
+# Guardrail hooks around tool calls (issue #525)
+# ==============================================================================
+# before_tool fires for every tool call including the internal complete_task
+# control-flow tool -- but complete_task returns immediately on success,
+# bypassing the after_tool invocation that every other tool call gets. A
+# guardrail that pairs before_tool/after_tool events (e.g. to measure tool
+# execution time or verify output) would see every complete_task call appear
+# open-ended, with no matching after_tool.
+
+
+from unittest.mock import AsyncMock, patch
+
+from finbot.core.data.models import LLMResponse
+from finbot.guardrails.schemas import HookKind
+
+
+class _AgentLoopTestAgent(BaseAgent):
+    """Minimal concrete BaseAgent for exercising the real _run_agent_loop,
+    including its async _get_user_prompt -- distinct from ConcreteTestAgent
+    above, whose _get_user_prompt is not async and was never actually run
+    through _run_agent_loop by any existing test."""
+
+    def _load_config(self) -> dict:
+        return {}
+
+    def _get_system_prompt(self) -> str:
+        return "You are a test agent."
+
+    async def _get_user_prompt(self, task_data: dict[str, Any] | None = None) -> str:
+        return "Test task"
+
+    def _get_tool_definitions(self) -> list[dict[str, Any]]:
+        return []
+
+    def _get_callables(self) -> dict[str, Callable[..., Any]]:
+        return {}
+
+    async def process(self, task_data: dict[str, Any], **kwargs) -> dict[str, Any]:
+        return await self._run_agent_loop(task_data=task_data)
+
+
+class TestGuardrailHooksAroundToolCalls:
+
+    def _create_session_context(self, email: str) -> SessionContext:
+        session = session_manager.create_session(email=email, user_agent="TestAgent/1.0")
+        created_at = datetime.now(UTC)
+        return SessionContext(
+            session_id=session.session_id,
+            user_id=f"user_{email.split('@')[0]}",
+            email=email,
+            namespace=f"user_{email.split('@')[0]}",
+            is_temporary=False,
+            created_at=created_at,
+            expires_at=created_at + timedelta(hours=24),
+        )
+
+    def _make_agent(self, email: str) -> _AgentLoopTestAgent:
+        return _AgentLoopTestAgent(session_context=self._create_session_context(email))
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_after_tool_fires_for_complete_task(self):
+        """The actual bug: this must include a before_tool/after_tool pair
+        for complete_task, not just before_tool."""
+        agent = self._make_agent("guardrail_hooks_1@example.com")
+        agent._guardrail_service.invoke = AsyncMock(return_value=None)
+
+        llm_response = LLMResponse(
+            content=None,
+            tool_calls=[{
+                "name": "complete_task",
+                "call_id": "call_1",
+                "arguments": {"task_status": "success", "task_summary": "done"},
+            }],
+        )
+
+        with patch("finbot.agents.base.event_bus") as mock_bus, \
+             patch("finbot.core.llm.contextual_client.event_bus", mock_bus), \
+             patch(
+                 "finbot.core.llm.contextual_client.ContextualLLMClient.chat",
+                 new_callable=AsyncMock,
+                 return_value=llm_response,
+             ):
+            mock_bus.emit_agent_event = AsyncMock()
+            mock_bus.emit_business_event = AsyncMock()
+            mock_bus.set_workflow_context = lambda *a, **kw: None
+            result = await agent._run_agent_loop(task_data={})
+
+        assert result["task_status"] == "success"
+
+        hook_kinds_fired = [
+            call.args[0] if call.args else call.kwargs.get("kind")
+            for call in agent._guardrail_service.invoke.call_args_list
+        ]
+        assert HookKind.before_tool in hook_kinds_fired
+        assert HookKind.after_tool in hook_kinds_fired
+
+        after_tool_calls = [
+            call for call in agent._guardrail_service.invoke.call_args_list
+            if (call.args[0] if call.args else call.kwargs.get("kind")) == HookKind.after_tool
+        ]
+        assert len(after_tool_calls) == 1
+        assert after_tool_calls[0].kwargs["tool_name"] == "complete_task"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_after_tool_still_fires_for_normal_tools(self):
+        """Regression guard: fixing complete_task's missing after_tool must
+        not change behavior for ordinary tool calls, which already fire
+        after_tool correctly today."""
+
+        class AgentWithOneTool(_AgentLoopTestAgent):
+            def _get_tool_definitions(self):
+                return [{
+                    "type": "function",
+                    "name": "do_something",
+                    "description": "test tool",
+                    "parameters": {"type": "object", "properties": {}},
+                }]
+
+            def _get_callables(self):
+                return {"do_something": self._do_something}
+
+            async def _do_something(self):
+                return {"result": "ok"}
+
+        agent = AgentWithOneTool(
+            session_context=self._create_session_context("guardrail_hooks_2@example.com")
+        )
+        agent._guardrail_service.invoke = AsyncMock(return_value=None)
+
+        responses = [
+            LLMResponse(
+                content=None,
+                tool_calls=[{"name": "do_something", "call_id": "call_1", "arguments": {}}],
+            ),
+            LLMResponse(
+                content=None,
+                tool_calls=[{
+                    "name": "complete_task",
+                    "call_id": "call_2",
+                    "arguments": {"task_status": "success", "task_summary": "done"},
+                }],
+            ),
+        ]
+
+        with patch("finbot.agents.base.event_bus") as mock_bus, \
+             patch("finbot.core.llm.contextual_client.event_bus", mock_bus), \
+             patch(
+                 "finbot.core.llm.contextual_client.ContextualLLMClient.chat",
+                 new_callable=AsyncMock,
+                 side_effect=responses,
+             ):
+            mock_bus.emit_agent_event = AsyncMock()
+            mock_bus.emit_business_event = AsyncMock()
+            mock_bus.set_workflow_context = lambda *a, **kw: None
+            await agent._run_agent_loop(task_data={})
+
+        tool_names_after_tool = [
+            call.kwargs["tool_name"]
+            for call in agent._guardrail_service.invoke.call_args_list
+            if (call.args[0] if call.args else call.kwargs.get("kind")) == HookKind.after_tool
+        ]
+        assert tool_names_after_tool.count("do_something") == 1
+        assert tool_names_after_tool.count("complete_task") == 1
         print(f"✓ BAF-COM-001: ALL ACCEPTANCE CRITERIA MET")

--- a/tests/unit/labs/test_guardrail_service.py
+++ b/tests/unit/labs/test_guardrail_service.py
@@ -10,8 +10,11 @@ import pytest
 
 from finbot.core.auth.session import session_manager
 from finbot.core.data.repositories import LabsGuardrailConfigRepository
-from finbot.guardrails.schemas import HookKind, HookOutcome
-from finbot.guardrails.service import GuardrailHookService
+from finbot.guardrails.schemas import HookEnvelope, HookKind, HookOutcome
+from finbot.guardrails.service import (
+    GuardrailHookService,
+    _truncate_envelope_for_payload_limit,
+)
 
 
 @pytest.fixture()
@@ -74,6 +77,109 @@ class TestConfigCaching:
             svc._load_config()
             svc._load_config()
             assert mock_get.call_count == 1
+
+
+# =============================================================================
+# Payload truncation (issue #525) -- must produce valid JSON, never a raw
+# byte-slice of the serialized body.
+# =============================================================================
+
+
+def _make_envelope(**overrides) -> HookEnvelope:
+    defaults = dict(
+        hook_kind=HookKind.after_tool,
+        session_id="sess_1",
+        workflow_id="wf_1",
+        tool_name="some_tool",
+        tool_source="native",
+        tool_arguments=None,
+        tool_result=None,
+        model=None,
+        user_message=None,
+        model_output=None,
+        timestamp="2026-08-20T00:00:00Z",
+    )
+    defaults.update(overrides)
+    return HookEnvelope(**defaults)
+
+
+class TestPayloadTruncation:
+
+    @pytest.mark.unit
+    def test_returns_unchanged_when_already_under_limit(self):
+        envelope = _make_envelope(tool_result="short")
+        result = _truncate_envelope_for_payload_limit(envelope, max_payload=65536)
+        assert result.tool_result == "short"
+
+    @pytest.mark.unit
+    def test_truncated_body_is_always_valid_json(self):
+        """The actual bug: a raw byte-slice of serialized JSON can cut a
+        string or multi-byte UTF-8 character mid-way, producing invalid
+        JSON. Field-level truncation must never do that. 300 bytes is
+        near the floor -- above the envelope's fixed-field overhead but
+        still forcing model_output to be truncated hard, including right
+        through a run of multi-byte UTF-8 characters."""
+        envelope = _make_envelope(
+            model_output="hello ééé world " * 500  # multi-byte chars
+        )
+        result = _truncate_envelope_for_payload_limit(envelope, max_payload=300)
+
+        body = result.model_dump_json().encode()
+        assert len(body) <= 300
+        json.loads(body)  # must not raise
+
+    @pytest.mark.unit
+    def test_truncates_long_tool_result(self):
+        envelope = _make_envelope(tool_result="x" * 5000)
+        result = _truncate_envelope_for_payload_limit(envelope, max_payload=500)
+        assert len(result.model_dump_json().encode()) <= 500
+        json.loads(result.model_dump_json())
+
+    @pytest.mark.unit
+    def test_truncates_long_user_message_and_model_output_together(self):
+        envelope = _make_envelope(
+            user_message="a" * 3000, model_output="b" * 3000
+        )
+        result = _truncate_envelope_for_payload_limit(envelope, max_payload=1000)
+        assert len(result.model_dump_json().encode()) <= 1000
+        json.loads(result.model_dump_json())
+
+    @pytest.mark.unit
+    def test_large_tool_arguments_replaced_with_truncation_marker(self):
+        """A dict can't be safely character-truncated without risking
+        invalid JSON -- must become a small, valid marker instead, not a
+        partially-cut object literal."""
+        envelope = _make_envelope(tool_arguments={"data": "y" * 5000})
+        result = _truncate_envelope_for_payload_limit(envelope, max_payload=500)
+
+        body = result.model_dump_json().encode()
+        assert len(body) <= 500
+        parsed = json.loads(body)
+        assert parsed["tool_arguments"]["_truncated"] is True
+        assert parsed["tool_arguments"]["keys"] == ["data"]
+        assert parsed["tool_arguments"]["original_size_bytes"] > 500
+
+    @pytest.mark.unit
+    def test_does_not_over_truncate_when_only_slightly_over_limit(self):
+        envelope = _make_envelope(tool_result="x" * 600)
+        result = _truncate_envelope_for_payload_limit(envelope, max_payload=590)
+        # Should still contain most of the content, not be wiped to empty
+        assert result.tool_result is not None
+        assert len(result.tool_result) > 0
+
+    @pytest.mark.unit
+    def test_pathological_max_payload_below_fixed_overhead(self):
+        """max_payload smaller than the envelope's own fixed-field
+        overhead: even with every truncatable field emptied, the result
+        can still exceed max_payload. Must not raise, and must still be
+        valid JSON -- this is the documented, accepted limit of a
+        best-effort truncation, not a crash."""
+        envelope = _make_envelope(tool_result="x" * 5000)
+        result = _truncate_envelope_for_payload_limit(envelope, max_payload=10)
+
+        body = result.model_dump_json().encode()
+        json.loads(body)  # must not raise
+        assert result.tool_result == ""
 
 
 # =============================================================================
@@ -146,6 +252,27 @@ class TestWebhookInvocation:
         assert call_kwargs["event_type"] == "webhook_completed"
         assert call_kwargs["event_data"]["verdict"] == "allow"
         assert call_kwargs["event_data"]["hook_kind"] == "before_tool"
+
+    @pytest.mark.asyncio
+    @patch("finbot.guardrails.service.event_bus")
+    async def test_invoke_never_raises_even_on_internal_failure(self, mock_bus):
+        """invoke()'s own docstring promises it never raises, so a bug or
+        outage anywhere in its plumbing (not just the HTTP call, which
+        already had its own try/except) can never propagate into a
+        caller's unrelated try/except and get misclassified as that
+        caller's own failure -- exactly the risk a reviewer flagged when
+        the after_tool call for complete_task in base.py's agent loop
+        landed inside the same try/except as the tool call itself."""
+        mock_bus.emit_agent_event = AsyncMock()
+
+        with patch(
+            "finbot.guardrails.service.GuardrailHookService._sign_payload",
+            side_effect=RuntimeError("boom"),
+        ):
+            svc = self._make_service()
+            outcome = await svc.invoke(HookKind.before_tool, tool_name="test")
+
+        assert outcome == HookOutcome.error
 
     @pytest.mark.asyncio
     @patch("finbot.guardrails.service.event_bus")
@@ -249,6 +376,45 @@ class TestWebhookInvocation:
         assert "X-Guardrail-Signature" in call_kwargs["headers"]
         assert "X-Guardrail-Timestamp" in call_kwargs["headers"]
         assert len(call_kwargs["headers"]["X-Guardrail-Signature"]) == 64  # SHA256 hex
+        assert "X-Guardrail-Truncated" not in call_kwargs["headers"]
+
+    @pytest.mark.asyncio
+    @patch("finbot.guardrails.service.event_bus")
+    async def test_oversized_payload_sends_valid_json_and_truncated_header(
+        self, mock_bus, monkeypatch
+    ):
+        """End-to-end proof for issue #525: a real oversized hook still
+        produces a body the receiver can json.loads() without error, with
+        a signature computed over that same valid body, plus an explicit
+        header telling the receiver truncation happened."""
+        mock_bus.emit_agent_event = AsyncMock()
+        monkeypatch.setattr(
+            "finbot.guardrails.service.settings.LABS_GUARDRAIL_MAX_PAYLOAD_BYTES", 300
+        )
+
+        resp = httpx.Response(200, json={"verdict": "allow"})
+        with patch(
+            "httpx.AsyncClient.post", new_callable=AsyncMock, return_value=resp
+        ) as mock_post:
+            svc = self._make_service()
+            await svc.invoke(
+                HookKind.after_model,
+                model="gpt-5-nano",
+                model_output="x" * 5000,
+            )
+
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["headers"]["X-Guardrail-Truncated"] == "true"
+        sent_body = call_kwargs["content"]
+        json.loads(sent_body)  # must not raise -- the actual bug being fixed
+
+        # Signature must be computed over the exact body that was sent.
+        expected_sig = GuardrailHookService._sign_payload(
+            sent_body,
+            svc._config.signing_secret,
+            call_kwargs["headers"]["X-Guardrail-Timestamp"],
+        )
+        assert call_kwargs["headers"]["X-Guardrail-Signature"] == expected_sig
 
     @pytest.mark.asyncio
     @patch("finbot.guardrails.service.event_bus")


### PR DESCRIPTION
## Summary

Two related bugs in the Labs guardrail webhook feature, both confirmed against current source before fixing.

### 1. Payload truncated mid-JSON before HMAC signing

`GuardrailHookService.invoke()` sliced the already-serialized JSON body at a raw byte offset when it exceeded the payload size limit, then signed those truncated bytes:

```python
body_bytes = envelope.model_dump_json().encode()
if len(body_bytes) > max_payload:
    body_bytes = body_bytes[:max_payload]   # raw byte slice
signature = self._sign_payload(body_bytes, ...)  # signs the broken bytes
```

Cutting a multi-byte UTF-8 character or a string/object literal mid-way produces a body that is neither valid UTF-8 nor valid JSON. The HMAC signature is computed over those broken bytes and still "validates" fine on the receiver's end — there's no way to detect the corruption from the signature alone.

**Fix:** `_truncate_envelope_for_payload_limit()` now truncates the envelope's long string fields (`tool_result`, `user_message`, `model_output`) individually, before serialization. Python string slicing operates on Unicode code points, so cutting a string at any character offset and then letting `model_dump_json()` re-serialize it always produces valid JSON, regardless of where the cut lands. `tool_arguments` is a dict, which can't be safely character-truncated without risking invalid JSON, so it's replaced with a small marker instead — `{"_truncated": true, "original_size_bytes": N, "keys": [...]}`, preserving the top-level key names so a receiver can still see which arguments existed. `invoke()` now also sets an `X-Guardrail-Truncated: true` response header when truncation occurred, so the receiver isn't left guessing.

### 2. `after_tool` never fires for the `complete_task` control-flow tool

In `finbot/agents/base.py`'s agent loop, `before_tool` fires for every tool call including the internal `complete_task` tool, but `complete_task` returned immediately on success, bypassing the `after_tool` invocation every other tool call gets a few lines later. Any guardrail pairing before/after events (e.g. to measure execution time or verify output) would see every `complete_task` call as permanently open-ended.

**Fix:** fires `after_tool` for `complete_task` too, immediately before the existing completion/return logic, using the same call signature as the sibling call site.

### 3. Found during our own review, not by the issue: `invoke()` could mask a successful task completion

The new `after_tool` call for `complete_task` sits inside the same `try/except` as the tool call it's observing — unlike the sibling call site for ordinary tools, which sits outside it. If anything in guardrail plumbing raised (config load, envelope construction, the new truncation logic, signing — none of which were previously wrapped, only the HTTP call itself was), the surrounding `except Exception` would have discarded the already-successful `function_output`, replaced it with a generic error, and let the loop continue instead of returning — silently converting a successful `complete_task` into a fake failure.

Fixed at the source rather than patched around the call site: `invoke()` is now wrapped so it can never raise under any circumstance, matching its own documented contract ("never gates execution on the verdict"). The original body moved to a private `_invoke()`; the public `invoke()` catches everything and returns `HookOutcome.error` on any unexpected failure. This also means the try/except placement question becomes moot — the call is now safe wherever it's placed.

## A note on merge overlap with #575

This branch and the already-open #575 (DNS-based SSRF fix, same guardrail feature) both add tests to `TestWebhookInvocation` in `tests/unit/labs/test_guardrail_service.py`. Verified independently: each branch merges cleanly into current `main` on its own. If both get merged, whichever lands second will show a real (if trivial) conflict in that one file, purely because both are adding tests to the same class. Flagging this now so it's not a surprise at merge time — happy to rebase/resolve once the merge order between the two is decided, just didn't want to guess at that order preemptively.

## Test plan

- [x] New `TestPayloadTruncation` class (`tests/unit/labs/test_guardrail_service.py`): unchanged-under-limit, valid-JSON-under-truncation (including multi-byte content), single/multi-field truncation, dict-marker replacement with preserved keys, no-over-truncation when barely over, and the pathological case where `max_payload` is smaller than the envelope's own fixed-field overhead (confirms no crash, still valid JSON, documented as a best-effort limit rather than a hard guarantee)
- [x] New integration test `test_oversized_payload_sends_valid_json_and_truncated_header`: proves `invoke()` sends a `json.loads()`-able body with a signature that matches it, plus the truncation header
- [x] New test `test_invoke_never_raises_even_on_internal_failure`: forces an exception in previously-unwrapped code (`_sign_payload`) and confirms `invoke()` still returns `HookOutcome.error` rather than propagating
- [x] New `TestGuardrailHooksAroundToolCalls` class (`tests/unit/agents/test_base_agent.py`): confirms `after_tool` now fires for `complete_task`, plus a regression guard that ordinary tool calls still get exactly one `after_tool` each
- [x] `pytest tests/unit/labs/test_guardrail_service.py tests/unit/agents/test_base_agent.py -v` — 38/38 passing
- [x] `pytest tests/unit/agents/ tests/unit/labs/ tests/unit/mcp/ -q` — 135 passed, no new failures
- [x] `pytest tests/unit/ -q` — full suite, 317 passed, 4 pre-existing failures unrelated to this change (present before it too)
- [x] Locally merge-tested against fresh `origin/main` — clean on its own and combined with #574; the one real conflict found (with #575, noted above) was isolated and confirmed precisely rather than assumed