### PR TITLE
Fix: profile share-card cache key omits fields that affect the render

### DIFF
--- a/finbot/apps/ctf/routes/share.py
+++ b/finbot/apps/ctf/routes/share.py
@@ -90,6 +90,58 @@ def get_cache_path(cache_key: str) -> Path:
     return CACHE_DIR / f"{cache_key}.png"
 
 
+def _profile_card_cache_key(
+    username: str,
+    total_points: int,
+    badges_earned: int,
+    challenges_completed: int,
+    avatar_type: str | None,
+    avatar_url: str | None,
+    avatar_emoji: str | None,
+    user_email: str | None,
+    bio: str | None,
+    earned_badge_ids: list[str],
+    featured_badge_ids: list[str],
+) -> str:
+    """Build the cache key for a rendered profile share-card.
+
+    Must include every field that affects the rendered image, not just
+    the point/badge/challenge counts -- otherwise two profiles (or the
+    same profile before/after an avatar or bio change) that happen to
+    share the same stats collide on the same cached file, and one user's
+    card gets served to the other, or a stale card is served forever
+    until stats next change.
+
+    avatar_type == "gravatar" resolves its image from user_email (see
+    resolve_avatar_url in profile.py), not from avatar_url -- omitting
+    user_email from the key would leave that specific case still
+    collision-prone even with avatar_url/avatar_emoji/bio included.
+
+    earned_badge_ids and featured_badge_ids are needed too, not just
+    their counts: a user can re-curate which earned badges are featured
+    (PUT /featured-badges) with no change to total_points/badges_earned/
+    challenges_completed, which would otherwise leave the card
+    permanently stale after a re-curation. Same reasoning covers
+    "latest badge" staleness if badge composition changes at an
+    unchanged total count. earned_badge_ids is sorted (composition, not
+    order, is what matters there); featured_badge_ids is kept in its
+    given order, since the card renders featured badges in the order
+    the user chose.
+    """
+    # \x1f (unit separator) rather than "," -- badge IDs are developer-
+    # defined slugs (e.g. "first-blood"), never user input, so a comma
+    # can't appear in practice, but this removes even the theoretical
+    # ["a,b"] + ["c"] vs. ["a"] + ["b,c"] ambiguity for free.
+    sep = "\x1f"
+    cache_data = (
+        f"{username}:{total_points}:{badges_earned}:{challenges_completed}"
+        f":{avatar_type or ''}:{avatar_url or ''}:{avatar_emoji or ''}"
+        f":{user_email or ''}:{bio or ''}"
+        f":{sep.join(sorted(earned_badge_ids))}:{sep.join(featured_badge_ids)}"
+    )
+    return hashlib.sha256(cache_data.encode()).hexdigest()
+
+
 async def _fetch_avatar_b64(url: str) -> str:
     """Fetch a remote avatar image and return it as a base64 data URI.
 
@@ -284,10 +336,19 @@ async def get_profile_card(
     if html and settings.DEBUG:
         return HTMLResponse(_render_html("profile_card.html", template_context))
 
-    cache_data = (
-        f"{username}:{total_points}:{len(earned_badges)}:{len(completed_progress)}"
+    cache_key = _profile_card_cache_key(
+        username=username,
+        total_points=total_points,
+        badges_earned=len(earned_badges),
+        challenges_completed=len(completed_progress),
+        avatar_type=profile.avatar_type,
+        avatar_url=profile.avatar_url,
+        avatar_emoji=profile.avatar_emoji,
+        user_email=user.email,
+        bio=profile.bio,
+        earned_badge_ids=earned_badge_ids,
+        featured_badge_ids=featured_ids,
     )
-    cache_key = hashlib.md5(cache_data.encode()).hexdigest()
     cache_path = get_cache_path(cache_key)
 
     if cache_path.exists():

--- a/tests/unit/apps/test_profile_card_cache_key.py
+++ b/tests/unit/apps/test_profile_card_cache_key.py
@@ -1,0 +1,165 @@
+# Tests for finbot.apps.ctf.routes.share._profile_card_cache_key (issue #508).
+#
+# Bug: the profile share-card cache key was built from only 4 fields
+# (username, total_points, badges_earned, challenges_completed). Two users
+# sharing the same stats (extremely common at 0/0/0 on registration)
+# collided on the identical cache file; whichever rendered first was
+# permanently served to the other. Same-user avatar/bio changes were also
+# invisible to the cache -- the old card stayed stale until stats changed.
+#
+# Also caught before writing the fix: the linked issue's own suggested fix
+# (adding avatar_type/avatar_url/avatar_emoji/bio to the key) has a real
+# gap -- resolve_avatar_url() (finbot/apps/ctf/routes/profile.py) resolves
+# the actual rendered image from user.email, not profile.avatar_url, when
+# avatar_type == "gravatar". A cache key missing user.email would still
+# collide for two gravatar-type profiles with matching stats and no bio,
+# even after applying the issue's own proposed fix verbatim.
+
+import pytest
+
+from finbot.apps.ctf.routes.share import _profile_card_cache_key
+
+
+def _key(**overrides):
+    defaults = dict(
+        username="alice",
+        total_points=100,
+        badges_earned=2,
+        challenges_completed=3,
+        avatar_type="emoji",
+        avatar_url=None,
+        avatar_emoji="🦊",
+        user_email="alice@example.com",
+        bio="hi",
+        earned_badge_ids=["badge_a", "badge_b"],
+        featured_badge_ids=["badge_a"],
+    )
+    defaults.update(overrides)
+    return _profile_card_cache_key(**defaults)
+
+
+class TestProfileCardCacheKey:
+
+    @pytest.mark.unit
+    def test_deterministic_for_identical_inputs(self):
+        assert _key() == _key()
+
+    @pytest.mark.unit
+    def test_different_usernames_produce_different_keys(self):
+        assert _key(username="alice") != _key(username="bob")
+
+    @pytest.mark.unit
+    def test_two_users_with_matching_stats_and_different_avatar_url_do_not_collide(self):
+        """The core bug: two users at identical stats (common at 0/0/0)
+        must not map to the same cache file just because points/badges/
+        challenges match -- their actual rendered avatar differs."""
+        key_a = _key(
+            username="alice", total_points=0, badges_earned=0, challenges_completed=0,
+            avatar_type="url", avatar_url="https://example.com/a.png",
+        )
+        key_b = _key(
+            username="bob", total_points=0, badges_earned=0, challenges_completed=0,
+            avatar_type="url", avatar_url="https://example.com/b.png",
+        )
+        assert key_a != key_b
+
+    @pytest.mark.unit
+    def test_avatar_url_change_invalidates_the_cache_key(self):
+        """Same user, same stats, changed avatar -- must get a new key,
+        not silently serve the old cached card forever."""
+        before = _key(avatar_type="url", avatar_url="https://example.com/old.png")
+        after = _key(avatar_type="url", avatar_url="https://example.com/new.png")
+        assert before != after
+
+    @pytest.mark.unit
+    def test_bio_change_invalidates_the_cache_key(self):
+        before = _key(bio="old bio")
+        after = _key(bio="new bio")
+        assert before != after
+
+    @pytest.mark.unit
+    def test_avatar_emoji_change_invalidates_the_cache_key(self):
+        before = _key(avatar_type="emoji", avatar_emoji="🦊")
+        after = _key(avatar_type="emoji", avatar_emoji="🐱")
+        assert before != after
+
+    @pytest.mark.unit
+    def test_gravatar_users_with_different_emails_do_not_collide(self):
+        """The gap in the linked issue's own suggested fix: for
+        avatar_type == "gravatar", the rendered image comes from
+        user.email (see resolve_avatar_url), not from avatar_url. Two
+        profiles with identical stats, avatar_type="gravatar", and no
+        avatar_url/bio set would still collide without user_email in the
+        key -- exactly the scenario the issue's own diff would have
+        missed."""
+        key_a = _key(
+            avatar_type="gravatar", avatar_url=None, bio=None,
+            user_email="alice@example.com",
+        )
+        key_b = _key(
+            avatar_type="gravatar", avatar_url=None, bio=None,
+            user_email="bob@example.com",
+        )
+        assert key_a != key_b
+
+    @pytest.mark.unit
+    def test_none_values_do_not_raise(self):
+        _profile_card_cache_key(
+            username="alice",
+            total_points=0,
+            badges_earned=0,
+            challenges_completed=0,
+            avatar_type=None,
+            avatar_url=None,
+            avatar_emoji=None,
+            user_email=None,
+            bio=None,
+            earned_badge_ids=[],
+            featured_badge_ids=[],
+        )  # must not raise
+
+    @pytest.mark.unit
+    def test_returns_a_hex_digest(self):
+        key = _key()
+        assert isinstance(key, str)
+        int(key, 16)  # must be valid hex
+
+    @pytest.mark.unit
+    def test_re_curating_featured_badges_invalidates_the_cache_key(self):
+        """PUT /featured-badges lets a user change which earned badges are
+        featured with zero change to total_points/badges_earned/
+        challenges_completed -- must not leave the card stale."""
+        before = _key(
+            earned_badge_ids=["a", "b", "c"], featured_badge_ids=["a", "b"]
+        )
+        after = _key(
+            earned_badge_ids=["a", "b", "c"], featured_badge_ids=["b", "c"]
+        )
+        assert before != after
+
+    @pytest.mark.unit
+    def test_featured_badge_order_change_invalidates_the_cache_key(self):
+        """The card renders featured badges in the user's chosen order --
+        a reorder with the same set must still bust the cache."""
+        before = _key(featured_badge_ids=["a", "b"])
+        after = _key(featured_badge_ids=["b", "a"])
+        assert before != after
+
+    @pytest.mark.unit
+    def test_earned_badge_composition_change_at_same_count_invalidates_the_key(self):
+        """Losing one badge and gaining a different one at the same total
+        count must still bust the cache -- badges_earned alone (a count)
+        can't distinguish this, and the composition change can also
+        silently change which badge is "latest"."""
+        before = _key(badges_earned=2, earned_badge_ids=["a", "b"])
+        after = _key(badges_earned=2, earned_badge_ids=["a", "c"])
+        assert before != after
+
+    @pytest.mark.unit
+    def test_earned_badge_order_does_not_matter_only_composition(self):
+        """Unlike featured badges, earned badges aren't displayed in a
+        user-chosen order on the card -- only which badges are earned
+        matters, so the key should be stable under reordering."""
+        key_a = _key(earned_badge_ids=["a", "b", "c"])
+        key_b = _key(earned_badge_ids=["c", "a", "b"])
+        assert key_a == key_b


### PR DESCRIPTION
## Summary

The public `/share/profile/{username}/card.png` endpoint caches rendered PNG cards to disk keyed on only 4 fields: `username`, `total_points`, `badges_earned`, `challenges_completed`. Two users sharing identical stats — common at 0/0/0 right after registration — collide on the identical cache file; whichever renders first is permanently served to the other. Same-user avatar/bio/featured-badge changes are also invisible to the cache: the old card stays stale indefinitely, with no way to invalidate it short of an admin manually deleting the file (there's no TTL/eviction anywhere for this cache directory).

## Beyond the linked issue's own suggested fix

The issue proposes adding `avatar_type`/`avatar_url`/`avatar_emoji`/`bio` to the key. Two real gaps in that proposal, found before writing anything:

1. **The gravatar case is still collision-prone.** `resolve_avatar_url()` (`finbot/apps/ctf/routes/profile.py`) resolves the actual rendered image from the user's **email** when `avatar_type == "gravatar"`, not from `avatar_url` at all:
   ```python
   if avatar_type == "gravatar" and user and user.email:
       return gravatar_url(user.email)
   ```
   Two profiles with `avatar_type="gravatar"`, matching stats, and no bio would still produce identical cache keys under the issue's own suggested fix. Added `user_email` to the key.

2. **Featured-badge re-curation is invisible.** `PUT /featured-badges` lets a user change which of their earned badges are featured, with zero change to the 4 count fields — a re-curation would leave the card permanently stale. The same gap covers "latest badge" staleness if badge composition changes at an unchanged total count (e.g. losing one badge and gaining a different one). Added `earned_badge_ids` (sorted before joining — badges aren't shown in a user-chosen order outside the featured section, only composition matters there) and `featured_badge_ids` (kept in the user's chosen order, since that IS what's rendered).

## Comparison against another open fix for the same issue

Another contributor has an independent, already-open PR (#510) for the same issue. Worth comparing openly since both are unmerged: #510 implements the issue's own suggested fix directly (`avatar_type`/`avatar_url`/`avatar_emoji`/`bio` added to the key, MD5→SHA-256 — genuinely equivalent to this PR on that part). It doesn't cover the two gaps above though, so it inherits both: a gravatar user changing their linked email still collides under #510's key, and a featured-badge re-curation still serves a stale card. Not a criticism of #510's approach, both gaps only turn up if you trace `resolve_avatar_url()` and the `/featured-badges` endpoint specifically rather than working from the issue's own field list — flagging so whoever merges has the full picture.

## Fix

Extracted `_profile_card_cache_key()` — a small, pure, directly-testable function (this file had zero test coverage before this change) — and wired it into the route using values already in scope. Also switched `hashlib.md5` to `hashlib.sha256`, per the issue's own optional-hardening suggestion (MD5 gets flagged by security scanners even in this non-adversarial cache-busting context). Joined badge-ID lists with `\x1f` (unit separator) rather than `,`, closing even the theoretical (not currently reachable, since badge IDs are developer-defined slugs, never user input) join-ambiguity case for free.

## Known, documented limitations (not fixed here, noted rather than silently ignored)

- **No cache eviction/TTL exists anywhere for this directory.** Widening the key (as this PR does) increases key cardinality per user, so disk usage grows faster after every edit — worth a follow-up issue for the cache directory itself, out of scope for a key-correctness fix.
- **Transient avatar-fetch failures get cached permanently.** If `_fetch_avatar_b64` fails (timeout, non-200, oversized image), the fallback-letter card is written to the cache and served for that key indefinitely, even after the fetch would have succeeded on retry. Pre-existing, not introduced by this diff.
- **No route-level integration test.** The pure cache-key function is fully covered directly, but there's no test exercising the actual route to confirm `profile`/`user` fields are threaded through correctly at the call site (e.g. an accidental future swap of `avatar_url`/`avatar_emoji` wouldn't be caught). Full route testing here needs the image-rendering pipeline (Playwright via `get_renderer()`), which has been unreliable in this dev environment this session — didn't want to build new, possibly-flaky test infra just for this fix. Noted as a gap, not silently skipped.

## Test plan

- [x] New `tests/unit/apps/test_profile_card_cache_key.py` (13 tests): deterministic for identical inputs; different usernames differ; two users with matching stats but different avatar don't collide; avatar_url/bio/avatar_emoji changes each invalidate the key; gravatar users with different emails don't collide; featured-badge re-curation invalidates the key; featured-badge reorder (same set) invalidates the key; earned-badge composition change at the same count invalidates the key; earned-badge reorder (same composition) does **not** invalidate the key (confirms the sort-before-join design is intentional, not an oversight); None values handled without raising; returns a valid hex digest
- [x] `pytest tests/unit/apps/ tests/unit/ctf/ -q` — 53 passed, 1 pre-existing unrelated skip
- [x] Module import sanity check
- [x] Locally merge-tested against fresh `origin/main`: clean on its own, and clean paired individually against every other currently-open PR from this batch (#574, #575, #576, #577) — zero new conflicts introduced by this branch
