### PR TITLE
fix: guard vendor_id/invoice_id=None in chat assistant tool callables (#418)

### DIFF
--- a/finbot/agents/chat.py
+++ b/finbot/agents/chat.py
@@ -702,22 +702,32 @@ Current date: {datetime.now(UTC).strftime("%Y-%m-%d")}"""
             "start_workflow": self._call_start_workflow,
         }
 
-    async def _call_get_vendor_details(self, vendor_id: int) -> str:
+    async def _call_get_vendor_details(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         result = await get_vendor_details(vendor_id, self.session_context)
         return json.dumps(result)
 
-    async def _call_get_invoice_details(self, invoice_id: int) -> str:
+    async def _call_get_invoice_details(self, invoice_id: int | None) -> str:
+        if invoice_id is None:
+            return json.dumps({"error": "invoice_id is required"})
         return json.dumps(await get_invoice_details(invoice_id, self.session_context))
 
-    async def _call_get_vendor_invoices(self, vendor_id: int) -> str:
+    async def _call_get_vendor_invoices(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         return json.dumps(await get_vendor_invoices(vendor_id, self.session_context))
 
-    async def _call_get_vendor_payment_summary(self, vendor_id: int) -> str:
+    async def _call_get_vendor_payment_summary(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         return json.dumps(
             await get_vendor_payment_summary(vendor_id, self.session_context)
         )
 
-    async def _call_get_vendor_contact_info(self, vendor_id: int) -> str:
+    async def _call_get_vendor_contact_info(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         return json.dumps(
             await get_vendor_contact_info(vendor_id, self.session_context)
         )
@@ -1096,22 +1106,32 @@ Current date: {datetime.now(UTC).strftime("%Y-%m-%d")}"""
                 ]
             )
 
-    async def _call_get_vendor_details(self, vendor_id: int) -> str:
+    async def _call_get_vendor_details(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         result = await get_vendor_details(vendor_id, self.session_context)
         return json.dumps(result)
 
-    async def _call_get_invoice_details(self, invoice_id: int) -> str:
+    async def _call_get_invoice_details(self, invoice_id: int | None) -> str:
+        if invoice_id is None:
+            return json.dumps({"error": "invoice_id is required"})
         return json.dumps(await get_invoice_details(invoice_id, self.session_context))
 
-    async def _call_get_vendor_invoices(self, vendor_id: int) -> str:
+    async def _call_get_vendor_invoices(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         return json.dumps(await get_vendor_invoices(vendor_id, self.session_context))
 
-    async def _call_get_vendor_payment_summary(self, vendor_id: int) -> str:
+    async def _call_get_vendor_payment_summary(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         return json.dumps(
             await get_vendor_payment_summary(vendor_id, self.session_context)
         )
 
-    async def _call_get_vendor_contact_info(self, vendor_id: int) -> str:
+    async def _call_get_vendor_contact_info(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         return json.dumps(
             await get_vendor_contact_info(vendor_id, self.session_context)
         )
@@ -1122,12 +1142,16 @@ Current date: {datetime.now(UTC).strftime("%Y-%m-%d")}"""
     async def _call_get_pending_actions_summary(self) -> str:
         return json.dumps(await get_pending_actions_summary(self.session_context))
 
-    async def _call_get_vendor_compliance_docs(self, vendor_id: int) -> str:
+    async def _call_get_vendor_compliance_docs(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         return json.dumps(
             await get_vendor_compliance_docs(vendor_id, self.session_context)
         )
 
-    async def _call_get_vendor_activity_report(self, vendor_id: int) -> str:
+    async def _call_get_vendor_activity_report(self, vendor_id: int | None) -> str:
+        if vendor_id is None:
+            return json.dumps({"error": "vendor_id is required"})
         return json.dumps(
             await get_vendor_activity_report(vendor_id, self.session_context)
         )

--- a/tests/unit/agents/test_chat_assistant_none_guards.py
+++ b/tests/unit/agents/test_chat_assistant_none_guards.py
@@ -1,0 +1,161 @@
+# Tests for issue #418: VendorChatAssistant/CoPilotAssistant's native tool
+# callables forward vendor_id/invoice_id straight to the underlying data
+# functions with no None check.
+#
+# Verified against current source before writing this (issue's cited line
+# number, 660, is stale -- the methods now live at ~705 and ~1099, in two
+# separate classes, VendorChatAssistant and CoPilotAssistant, both with
+# byte-identical vulnerable implementations -- confirmed this is 10 call
+# sites, not 5).
+#
+# Also corrected before writing the fix: the issue claims "TypeError (or a
+# SQLAlchemy error)" propagates. Traced the actual behavior instead of
+# trusting that -- get_vendor_details/get_vendor_contact_info/
+# get_vendor_payment_summary all raise ValueError("Vendor not found") (via
+# VendorRepository.get_vendor(None), which is valid SQL -- `id IS NULL` --
+# just never matches a real primary key row); get_invoice_details raises
+# ValueError("Invoice not found") the same way; get_vendor_invoices raises
+# ValueError("Vendor not found or access denied") via
+# InvoiceRepository.list_invoices_for_specific_vendor's own vendor-
+# ownership check. All five are ValueError, not TypeError -- the exception
+# is application code intentionally rejecting a not-found lookup, not a
+# raw DB-driver crash. The uncaught-exception bug itself is still real
+# either way.
+
+import json
+
+import pytest
+
+from finbot.agents.chat import CoPilotAssistant, VendorChatAssistant
+from finbot.core.auth.session import session_manager
+
+
+@pytest.fixture()
+def session(db):
+    return session_manager.create_session(email="chat_none_guard@example.com")
+
+
+class TestVendorChatAssistantNoneGuards:
+
+    def _make_assistant(self, session) -> VendorChatAssistant:
+        return VendorChatAssistant(session_context=session)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_details_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_details(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_invoice_details_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_invoice_details(invoice_id=None)
+        assert json.loads(result) == {"error": "invoice_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_invoices_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_invoices(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_payment_summary_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_payment_summary(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_contact_info_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_contact_info(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+
+class TestVendorChatAssistantExecuteToolIntegration:
+    """Documents the real severity of issue #418: even pre-fix, a None
+    vendor_id was never an uncaught crash reaching the LLM/user. Every
+    _call_* method runs through _execute_tool, which already wraps the
+    call in a broad try/except and converts any exception (including the
+    pre-fix ValueError("Vendor not found")) into a JSON error string. The
+    actual bug this fix closes is a misleading error message ("vendor not
+    found" instead of "you forgot to supply vendor_id"), which could lead
+    the LLM to reason incorrectly (e.g. concluding a real vendor doesn't
+    exist) rather than an application crash."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_none_vendor_id_reaches_llm_as_clean_error_via_execute_tool(
+        self, db, session
+    ):
+        assistant = VendorChatAssistant(session_context=session)
+        result = await assistant._execute_tool(
+            "get_vendor_details", {"vendor_id": None}
+        )
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+
+class TestCoPilotAssistantNoneGuards:
+    """Same 5 methods exist a second time on CoPilotAssistant -- byte-
+    identical implementations before the fix, confirmed by reading the
+    source directly, not assumed from the class name alone."""
+
+    def _make_assistant(self, session) -> CoPilotAssistant:
+        return CoPilotAssistant(session_context=session)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_details_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_details(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_invoice_details_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_invoice_details(invoice_id=None)
+        assert json.loads(result) == {"error": "invoice_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_invoices_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_invoices(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_payment_summary_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_payment_summary(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_contact_info_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_contact_info(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_compliance_docs_none_returns_clean_error(self, db, session):
+        """Not in the issue's own stated 5-method list -- found while
+        auditing the rest of _build_native_callables() for the same
+        pattern. CoPilotAssistant-only, no vendor-portal equivalent
+        exists."""
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_compliance_docs(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_vendor_activity_report_none_returns_clean_error(self, db, session):
+        assistant = self._make_assistant(session)
+        result = await assistant._call_get_vendor_activity_report(vendor_id=None)
+        assert json.loads(result) == {"error": "vendor_id is required"}


### PR DESCRIPTION
Fixes #418.

## The bug

`VendorChatAssistant` and `CoPilotAssistant`'s native tool callables forward `vendor_id`/`invoice_id` straight to the underlying data functions with no None check. If the LLM calls a tool without supplying the ID argument, it reaches the data layer as `None`.

## Corrections made against the linked issue

- **Scope is 12 call sites, not 5.** The issue lists 5 methods on one class. In practice the same 5 methods are duplicated byte-for-byte across both `VendorChatAssistant` (vendor-portal-facing, `POST /chat`) and `CoPilotAssistant` (admin-portal-facing, `POST /copilot/chat`) — 10 sites total. Auditing the rest of `_build_native_callables()` for the same pattern turned up two more CoPilotAssistant-only methods with the identical gap: `_call_get_vendor_compliance_docs` and `_call_get_vendor_activity_report`. 12 sites fixed total.
- **Exception type correction.** The issue says a `TypeError` (or a raw SQLAlchemy error) propagates. Traced the actual behavior instead of trusting that: SQLAlchemy translates `Column == None` into a valid `IS NULL` clause, so e.g. `VendorRepository.get_vendor(None)` just returns no matching row (primary keys are never NULL) rather than raising anything at the DB layer. It's the application code's own `if not X: raise ValueError(...)` checks that actually fire. Every affected path raises `ValueError`, never `TypeError`.
- **Severity correction.** Every one of these methods is called exclusively through `_execute_tool`, which already wraps the call in a broad `try/except Exception` and converts any exception into a clean JSON error string before it reaches the LLM. So a `None` ID here was never an uncaught crash — the real (still worth fixing) bug is a misleading error message (e.g. "Vendor not found" when the actual problem is "you forgot to pass vendor_id"), which risks the LLM reasoning incorrectly, like concluding a real vendor doesn't exist.

## Fix

Added an explicit `is None` guard at the top of all 12 methods, returning `{"error": "<field> is required"}` before the call reaches the data layer, and widened the type hints to `int | None` to reflect reality.

## Tests

13 new tests in `tests/unit/agents/test_chat_assistant_none_guards.py`: one per guarded method (5 on `VendorChatAssistant`, 7 on `CoPilotAssistant`), plus one integration test through `_execute_tool` documenting the severity-correction point above. Confirmed RED before the fix, GREEN after.

## Test plan

- [x] 13 new unit tests pass
- [x] Broader regression (`tests/unit/agents/`, `tests/unit/ctf/`) run — 3 pre-existing failures in `test_specialized_agents.py` confirmed unrelated (different agent classes, reproduced on a clean stash of this branch's change, i.e. present on `main` without this fix)
- [x] Local merge-tested solo against fresh `origin/main` — clean
- [x] Local merge-tested pairwise against #574, #575, #576, #577, #578 — all clean